### PR TITLE
Start hidden when launched from autostart

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,8 @@ fn main() -> windows::core::Result<()> {
         return Ok(());
     };
 
-    platform::win::run()
+    let start_hidden = std::env::args().any(|arg| arg == platform::win::AUTOSTART_ARG);
+    platform::win::run(start_hidden)
 }
 
 #[cfg(test)]

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -38,6 +38,7 @@ use self::{
         set_window_icons,
     },
 };
+pub(crate) const AUTOSTART_ARG: &str = "--autostart";
 use crate::{
     app::AppState,
     config,
@@ -285,7 +286,7 @@ fn on_create(hwnd: HWND) -> LRESULT {
 /// This function is called from `main` after the single instance
 /// guard has been acquired.  It performs all initialization that
 /// requires unsafe code and returns any error to the caller.
-pub fn run() -> Result<()> {
+pub fn run(start_hidden: bool) -> Result<()> {
     unsafe {
         visuals::init_visuals();
         let class_name = w!("RustSwitcherMainWindow");
@@ -300,7 +301,8 @@ pub fn run() -> Result<()> {
 
         let hwnd = create_main_window(class_name, hinstance, style, x, y, window_w, window_h)?;
         set_window_icons(hwnd, hinstance);
-        let _ = ShowWindow(hwnd, SW_SHOW);
+        let show_cmd = if start_hidden { SW_HIDE } else { SW_SHOW };
+        let _ = ShowWindow(hwnd, show_cmd);
 
         message_loop()?;
     }

--- a/src/platform/win/autostart.rs
+++ b/src/platform/win/autostart.rs
@@ -172,6 +172,12 @@ fn create_shortcut(link_path: &Path, exe_path: &Path) -> windows::core::Result<(
         "IShellLinkW::SetPath",
     )?;
 
+    let args_w = to_wide(OsStr::new(super::AUTOSTART_ARG));
+    with_ctx(
+        unsafe { shell_link.SetArguments(PCWSTR(args_w.as_ptr())) },
+        "IShellLinkW::SetArguments",
+    )?;
+
     if let Some(dir) = exe_path.parent() {
         let dir_w = to_wide(dir.as_os_str());
         with_ctx(


### PR DESCRIPTION
### Motivation
- When the application is launched via a Windows "Startup" shortcut it should start minimized to the tray instead of showing the main window.

### Description
- Added `AUTOSTART_ARG` constant (`"--autostart"`) to `src/platform/win.rs` and used it when creating the autostart shortcut.
- Updated `create_shortcut` to set the shortcut's arguments so the app is launched with `--autostart`.
- Made `main` detect the `--autostart` argument and pass a `start_hidden` flag into `platform::win::run(start_hidden)`.
- Changed `platform::win::run` to accept `start_hidden: bool` and call `ShowWindow` with `SW_HIDE` when `start_hidden` is true.

### Testing
- No automated tests were executed for this change.
- Manual runtime verification was not recorded in the automated test log.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc8d93d7c8332ad4030f4688f6326)