### PR TITLE
ci: add Swatinem/rust-cache to release and build-windows workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ runner.os }}-x86_64-unknown-linux-gnu
+          shared-key: release-${{ runner.os }}-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/rust-toolchain.toml') }}
+
       - name: Cargo fmt
         run: cargo fmt --check
 
@@ -140,6 +146,12 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: build-windows-${{ runner.os }}-x86_64-pc-windows-msvc
+          shared-key: build-windows-${{ runner.os }}-x86_64-pc-windows-msvc-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/rust-toolchain.toml') }}
 
       - name: Build release binary
         run: cargo build --release --locked


### PR DESCRIPTION
### Motivation
- Speed up CI by caching Rust build artifacts and dependencies across runs for the `release` and `build-windows` jobs.
- Ensure cache separation by OS/target and invalidate caches when dependencies change by including `Cargo.lock` in the key.
- Ensure the cache is aware of toolchain changes by including `rust-toolchain.toml` in the cache key.
- Place caching after `Install Rust` so the toolchain is present before cache restore/save.

### Description
- Added a `Rust cache` step using `Swatinem/rust-cache@v2` immediately after `Install Rust` in the `release` job.
- Added the same `Rust cache` step in the `build-windows` job before the `cargo build --release --locked` step.
- Cache keys include an OS/target prefix plus `hashFiles('**/Cargo.lock')` and `hashFiles('**/rust-toolchain.toml')` in the `shared-key` to account for dependency and toolchain changes.
- No other workflow steps were modified; existing build, test, packaging, and release steps remain unchanged.

### Testing
- No automated tests or workflow runs were executed for this change since it only updates GitHub Actions workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd6b9d99083329cca4801e9ea244e)