### PR TITLE
Cache cargo-edit binary in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      RUST_TOOLCHAIN: stable
+      CARGO_EDIT_VERSION: "0.13.0"
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -45,6 +48,13 @@ jobs:
           key: release-${{ runner.os }}-x86_64-unknown-linux-gnu
           shared-key: release-${{ runner.os }}-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/rust-toolchain.toml') }}
 
+      - name: Cache cargo binaries
+        id: cargo-bin-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-${{ env.CARGO_EDIT_VERSION }}
+
       - name: Cargo fmt
         run: cargo fmt --check
 
@@ -70,7 +80,8 @@ jobs:
         run: cargo test --all-features ${{ steps.test-args.outputs.args }}
 
       - name: Install cargo-edit
-        run: cargo install cargo-edit --locked
+        if: steps.cargo-bin-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-edit --locked --version $CARGO_EDIT_VERSION
 
       - name: Bump version
         run: cargo set-version --bump ${{ inputs.bump }}


### PR DESCRIPTION
### Motivation
- Speed up the `release` workflow by caching the installed `cargo-edit` binary instead of reinstalling it on every run.
- Ensure the cache is invalidated when the OS, Rust toolchain, or `cargo-edit` version changes by including those in the cache key.
- Pin the `cargo-edit` version used during install to make caching deterministic and reproducible.
- Use the cached binary when available to avoid running `cargo install` unnecessarily.

### Description
- Added environment variables `RUST_TOOLCHAIN` and `CARGO_EDIT_VERSION` to the `release` job and set `CARGO_EDIT_VERSION` to `"0.13.0"`.
- Added a cache step using `actions/cache@v4` that caches `~/.cargo/bin` with a key that includes `${{ runner.os }}`, `${{ env.RUST_TOOLCHAIN }}`, and `${{ env.CARGO_EDIT_VERSION }}`.
- Modified the `Install cargo-edit` step to run only when the cache is a miss by checking `steps.cargo-bin-cache.outputs.cache-hit != 'true'` and to install the pinned version with `cargo install cargo-edit --locked --version $CARGO_EDIT_VERSION`.
- Left the rest of the `release` workflow unchanged, including existing `cargo fmt` and `cargo test` steps.

### Testing
- No automated workflow runs were executed as part of this change because it only updates the CI workflow configuration.
- No unit or integration tests were triggered locally by this commit.
- The repository changes were committed and staged for PR creation successfully.
- Manual verification of the diff shows the `release.yml` updates were applied without affecting other files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd83eae288332a171825354b1f3cf)