### PR TITLE
Run crates.io publish step on Windows runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ on:
         default: true
 
       do_publish_crates:
-        description: "Step 2 (Ubuntu): publish to crates.io (uses tag ref)"
+        description: "Step 2 (Windows): publish to crates.io (uses tag ref)"
         type: boolean
         required: true
         default: true
@@ -272,7 +272,7 @@ jobs:
 
   publish_crates:
     name: "Step 2 - publish to crates.io (tag ref)"
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs: determine_tag
     if: "${{ inputs.do_publish_crates }}"
 
@@ -291,10 +291,18 @@ jobs:
           shared-key: "release"
 
       - name: Verify nightly toolchain
-        shell: bash
+        shell: pwsh
         run: |
-          rustc -Vv
-          rustc -Vv | grep -q 'release:.*nightly'
+          $vv = (rustc -Vv) -join "`n"
+          Write-Host $vv
+          if ($vv -notmatch "release:\s+.*nightly") {
+            Write-Error "Expected nightly toolchain from rust-toolchain.toml, but rustc -Vv does not show nightly."
+            exit 1
+          }
+
+      - name: Build (locked)
+        shell: pwsh
+        run: cargo build -p rust-switcher --release --locked
 
       - name: Publish to crates.io
         env:


### PR DESCRIPTION
### Motivation
- The release flow needs crates publishing and verification to run on Windows because the project targets Windows and the previous publish job ran on Ubuntu. 
- The publish step should perform a locked Windows build and verify the nightly toolchain before calling `cargo publish --locked`.

### Description
- Change the `publish_crates` job to run on `windows-latest` and update the workflow dispatch description to reflect Windows. 
- Replace the bash nightly verification with a PowerShell check that validates `rustc -Vv` contains `nightly`. 
- Add a pre-publish Windows locked build step that runs `cargo build -p rust-switcher --release --locked`. 
- Keep the publish command as `cargo publish --locked` and preserve the existing cache and checkout steps. 

### Testing
- No automated CI jobs were executed as part of this change because it is a workflow modification only. 
- The change was committed to the branch and prepared as a PR for repository CI to run on merge or dispatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7eb0d3bc8332899eecde0ba7b1a7)