### PR TITLE
Fix release workflow to install `cargo-set-version` via binstall

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ run-name: "Release on ${{ github.ref_name }} bump ${{ inputs.bump }} | bump_tag=
 #   Step 4: create GitHub Release and attach the zip (tag)
 # - Caching and tooling:
 #   - Use Swatinem/rust-cache@v2 in all jobs to cache cargo registry, git deps, and target artifacts
-#   - Use cargo-binstall to install helper cargo subcommands fast (cargo-edit)
+#   - Use cargo-binstall to install helper cargo subcommands fast (cargo-set-version)
 
 on:
   workflow_dispatch:
@@ -103,9 +103,9 @@ jobs:
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@v1.16.6
 
-      - name: Install cargo-edit via binstall
+      - name: Install cargo-set-version via binstall
         shell: pwsh
-        run: cargo binstall cargo-edit -y --version 0.13.0
+        run: cargo binstall cargo-set-version -y
 
       - name: Compute next version from latest repo tag and Cargo.toml, set version, update lock
         id: version


### PR DESCRIPTION
### Motivation
- The Windows release job failed because `cargo set-version` was not available in the runner, causing the version bump step to error. 
- The release workflow intends to use a helper cargo subcommand installed via `cargo-binstall` for fast installation. 
- The workflow previously installed `cargo-edit` but actually needs `cargo-set-version` for the automated bump step. 

### Description
- Updated workflow comment to reference `cargo-set-version` instead of `cargo-edit` to reflect the intended tool. 
- Replaced the step label to `Install cargo-set-version via binstall` for clarity. 
- Changed the install command from `cargo binstall cargo-edit -y --version 0.13.0` to `cargo binstall cargo-set-version -y` in `.github/workflows/release.yml`. 

### Testing
- No automated tests were run because this is a CI workflow-only change. 
- The repository was updated and the change was committed successfully, but the release workflow run was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d87559a088332926729afc3e4a1df)