### PR TITLE
Add `strip = "symbols"` to release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ embed-resource = "3.0"
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = "symbols"
 
 [dev-dependencies]
 tracing-test = "0.2.5"


### PR DESCRIPTION
### Motivation

- Reduce the size of release builds by stripping debug symbols from the produced binaries.
- Make release artifacts smaller and more suitable for distribution when symbols are not required.
- Apply the setting directly in `Cargo.toml` under the release profile to affect all cargo release builds.

### Description

- Updated `Cargo.toml` to add `strip = "symbols"` under the `[profile.release]` section.
- The change is limited to the release profile and preserves existing settings `lto`, `codegen-units`, and `panic`.
- Only `Cargo.toml` was modified.

### Testing

- No automated tests were executed for this change.
- Repository operations like staging and committing the change succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f6e9232908332be3ed602d67317f0)