### PR TITLE
fix: include Windows release zip in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: windows-gnu-asset
+          path: .
+          merge-multiple: true
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### Motivation

- GitHub releases were missing the Windows binary archive, leaving releases without the expected .exe artifact.
- The release publisher `softprops/action-gh-release@v2` attaches files by globbing `*.zip` from the job workspace, so the zip must be present there.
- The artifact produced by the build job was uploaded but not guaranteed to be placed into the release job workspace, so it was not picked up for publishing.

### Description

- Updated ` .github/workflows/release.yml` to download the `windows-gnu-asset` into the release job workspace by adjusting the `actions/download-artifact@v4` step. 
- Added `path: .` to write artifacts into the current workspace directory and `merge-multiple: true` to combine multiple matching uploads.
- This ensures the produced `rust-switcher-*-windows-x86_64-gnu.zip` is present when `softprops/action-gh-release@v2` runs and its `files: "*.zip"` glob can find the archive.

### Testing

- No automated tests were run because this is a workflow-only change.
- The change is limited to `.github/workflows/release.yml` and does not affect runtime code or unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe1cebfa08332b6a1f4f1e902d987)