### PR TITLE
Validate config hotkey sequences during deserialization

### DIFF
--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -230,17 +230,6 @@ fn load_config_or_default(hwnd: HWND, state: &mut AppState) -> config::Config {
             );
         })
         .ok()
-        .and_then(|cfg| match cfg.validate_hotkey_sequences() {
-            Ok(()) => Some(cfg),
-            Err(msg) => {
-                let user_text = msg.clone();
-                let source = io_to_win(std::io::Error::new(std::io::ErrorKind::InvalidInput, msg));
-                crate::platform::ui::error_notifier::push(
-                    hwnd, state, T_CONFIG, &user_text, &source,
-                );
-                None
-            }
-        })
         .unwrap_or_default()
 }
 


### PR DESCRIPTION
### Motivation
- Reject invalid hotkey sequences as early as possible by validating during parsing ("parse, don’t validate"), so malformed config files never produce an invalid runtime Config.
- Simplify runtime config loading logic by moving sequence validation into deserialization.

### Description
- Introduce a `ConfigWire` intermediate type and implement `TryFrom<ConfigWire> for Config` which calls `validate_hotkey_sequences` and returns an error on invalid sequences.
- Implement a custom `Deserialize` for `Config` that deserializes to `ConfigWire` and converts it with `TryFrom`, mapping validation failures to serde errors, and add `Deserializer` import.
- Remove the derived `Deserialize` from `Config` and remove the manual post-load validation in `load_config_or_default` so `confy::load`/deserialization failure triggers the existing load error path.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968cec3528c8332b04488ef092035a4)