### PR TITLE
Treat '&' as Latin punctuation; add &↔? mapping and tests

### DIFF
--- a/src/domain/text/mapping.rs
+++ b/src/domain/text/mapping.rs
@@ -29,7 +29,7 @@ pub fn convert_ru_en_bidirectional(text: &str) -> String {
                 ch,
                 
                 '[' | ']' | ';' | '\'' | ',' | '.' | '`' | '{' | '}' | ':' | '"' | '<' | '>' | '~'
-                    | '?' | '/'
+                    | '?' | '/' | '&'
             )
     }
 
@@ -47,6 +47,7 @@ pub fn convert_ru_en_bidirectional(text: &str) -> String {
             // punctuation rules you requested
             ',' => '?',
             '.' => '/',
+            '?' => '&',
 
             'Й' => 'Q', 'Ц' => 'W', 'У' => 'E', 'К' => 'R', 'Е' => 'T', 'Н' => 'Y', 'Г' => 'U', 'Ш' => 'I', 'Щ' => 'O', 'З' => 'P',
             'Х' => '{', 'Ъ' => '}',
@@ -73,6 +74,7 @@ pub fn convert_ru_en_bidirectional(text: &str) -> String {
             // punctuation rules you requested
             '?' => ',',
             '/' => '.',
+            '&' => '?',
 
             'Q' => 'Й', 'W' => 'Ц', 'E' => 'У', 'R' => 'К', 'T' => 'Е', 'Y' => 'Н', 'U' => 'Г', 'I' => 'Ш', 'O' => 'Щ', 'P' => 'З',
             '{' => 'Х', '}' => 'Ъ',

--- a/src/tests/mapping_invariants_tests.rs
+++ b/src/tests/mapping_invariants_tests.rs
@@ -59,3 +59,9 @@ fn punctuation_rules_apply_only_in_en_to_ru_mode() {
     // Cyr dominates: ru_to_en, so '/' is not remapped by en_to_ru punctuation rule
     assert_eq!(convert_ru_en_bidirectional("/а"), "/f");
 }
+
+#[test]
+fn ampersand_prefers_latin_direction_when_present() {
+    assert_eq!(convert_ru_en_bidirectional("a&"), "ф?");
+    assert_eq!(convert_ru_en_bidirectional("я?"), "z&");
+}


### PR DESCRIPTION
### Motivation
- Ensure `&` is considered Latin punctuation when choosing conversion direction so layout selection behaves correctly for mixed text.
- Support the physical key mapping where `&` (EN) corresponds to `?` (RU) on shifted `7` in the Russian layout.

### Description
- Updated `is_latin` in `src/domain/text/mapping.rs` to include `&` as Latin punctuation so it contributes to Latin dominance counting.
- Added reciprocal punctuation mappings in `src/domain/text/mapping.rs`: `? => '&'` in `map_ru_to_en` and `& => '?'` in `map_en_to_ru` to reflect the shifted `7` key behavior.
- Added a new test `ampersand_prefers_latin_direction_when_present` in `src/tests/mapping_invariants_tests.rs` that asserts `convert_ru_en_bidirectional("a&") == "ф?"` and `convert_ru_en_bidirectional("я?") == "z&"`.

### Testing
- No automated tests were executed in this rollout; changes include unit tests that will run under the repository test suite (e.g. `cargo +nightly test --locked`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978baf9e2988332ac7d166561ae5988)