### PR TITLE
chore: bump release-please action to v4

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Release-please
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@v4
         with:
           # Specify the type of project. Rust crates use the 'rust' release type,
           # which will update Cargo.toml and Cargo.lock and generate release


### PR DESCRIPTION
### Motivation
- Update the release automation to a newer `google-github-actions/release-please-action` version while preserving existing workflow parameters and write permissions for `contents` and `pull-requests`.

### Description
- Replace `google-github-actions/release-please-action@v3` with `@v4` in `.github/workflows/release-pr.yml` and leave the `with:` parameters (`release-type`, `package-name`, `default-branch`, `version-file`, `extra-files`, `create-release`, `token`) and the `permissions` (`contents: write`, `pull-requests: write`) unchanged.

### Testing
- Ran `cargo +nightly fmt --check` (success), `cargo +nightly clippy --all-targets --all-features -- -D warnings` (failed due to missing Windows `windows` crate/toolchain on this non-Windows environment), `cargo +nightly build --features debug-tracing` (failed for same reason), and `cargo +nightly test --locked` (failed for same reason).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842e8affa48332b6a4985bf6dca97e)