### PR TITLE
chore: bump release-please action to v4

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Release-please
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@v4
         with:
           # Specify the type of project. Rust crates use the 'rust' release type,
           # which will update Cargo.toml and Cargo.lock and generate release


### PR DESCRIPTION
### Motivation
- Upgrade the GitHub `release-please` action to v4 to ensure Node 20 compatibility and keep the Release PR workflow production-ready.

### Description
- Update `.github/workflows/release-pr.yml` to use `google-github-actions/release-please-action@v4` instead of `@v3`.

### Testing
- Ran `cargo +nightly fmt --check` which succeeded.
- Ran `cargo +nightly clippy --all-targets --all-features -- -D warnings` which failed on this host because the `windows` crate is unavailable on non-Windows environments.
- Ran `cargo +nightly build --features debug-tracing` which failed on this host for the same `windows` crate issue.
- Ran `cargo +nightly test --locked` which failed on this host for the same `windows` crate issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842cc2fcd88332b689bdc68e5b43ed)