### PR TITLE
docs: add Justfile help/default recipe and descriptions

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,28 +1,37 @@
 set dotenv-load := true
 set shell := ["pwsh", "-NoLogo", "-NoProfile", "-Command"]
 
-default:
+# Show all available recipes.
+default: help
+
+# List all recipes with descriptions.
+help:
   @just --list
 
 # -----------------------------
 # Quality gates
 # -----------------------------
 
+# Check formatting.
 fmt:
   cargo fmt --check
 
+# Run clippy with CI flags.
 clippy:
   cargo clippy --all-targets --all-features --locked -- -D warnings
 
+# Run the test suite.
 test:
   cargo test --locked
 
+# Run all quality checks.
 check: fmt clippy test
 
 # -----------------------------
 # Release helpers
 # -----------------------------
 
+# Bump Cargo.toml (and Cargo.lock) version and commit.
 bump VERSION:
   $ErrorActionPreference = 'Stop'
   $version = '{{VERSION}}'
@@ -44,6 +53,7 @@ bump VERSION:
   }
   git commit -m "chore: bump version to $version"
 
+# Create and auto-merge a release PR from dev to main.
 publish:
   $ErrorActionPreference = 'Stop'
   $branch = git rev-parse --abbrev-ref HEAD


### PR DESCRIPTION
### Motivation
- Make `just` show a helpful list of available recipes by default and provide short descriptions so users can discover commands quickly.

### Description
- Change `default` target to `help`, add a `help` recipe that runs `just --list`, and add short descriptive comments for existing recipes in `Justfile`.

### Testing
- Ran formatting and CI checks: `cargo +nightly fmt --check` succeeded; `cargo +nightly clippy --all-targets --all-features -- -D warnings`, `cargo +nightly build --features debug-tracing`, and `cargo +nightly test --locked` failed in this environment due to missing Windows-specific dependencies and platform APIs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698438e15bbc83329c3eb8dbf476e749)