### PR TITLE
Configure Dependabot and CI-gated auto-merge for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "deps"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: dependabot-auto-merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for Dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- added `.github/dependabot.yml` to enable weekly dependency update PRs for:
  - Rust crates (`cargo` ecosystem)
  - GitHub Actions (`github-actions` ecosystem)
- configured labels and commit prefixes for easier triage (`dependencies`, `rust`, `ci`)
- grouped all Rust dependency bumps into a single Dependabot PR (`rust-dependencies`) to reduce PR noise
- added `.github/workflows/dependabot-auto-merge.yml` to automatically enable squash auto-merge for Dependabot PRs

## Behavior after this PR
- Dependabot will regularly scan and open update PRs for Cargo and Actions dependencies.
- For Dependabot PRs, GitHub will set auto-merge and wait until required CI checks pass.
- Merge happens only after CI gates are green and branch protection requirements are satisfied.

## Notes
- Auto-merge relies on repository/branch protections and required status checks being configured in GitHub settings.
- The workflow uses `pull_request_target` with an actor check (`dependabot[bot]`) and does not check out or execute PR code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e02a3a98833291c9a3329ba3ea78)