### PR TITLE
Set tray tooltip to "Rust Switcher" and preserve it on icon updates

### DIFF
--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -766,7 +766,7 @@ fn set_autoconvert_enabled_from_tray(
         format!("Status: paused.\nAuto convert: OFF.\nToggle: {hotkey_text}")
     };
 
-    if let Err(e) = crate::platform::win::tray::balloon_info(hwnd, "RustSwitcher", &body) {
+    if let Err(e) = crate::platform::win::tray::balloon_info(hwnd, "Rust Switcher", &body) {
         tracing::warn!(error = ?e, "tray balloon failed");
     }
 }

--- a/src/platform/win/tray.rs
+++ b/src/platform/win/tray.rs
@@ -30,6 +30,7 @@ const ID_EXIT: u32 = 1001;
 const ID_SHOW_HIDE: u32 = 1002;
 const ID_AUTOCONVERT_TOGGLE: u32 = 1003;
 const ID_CHANGE_THEME: u32 = 1004;
+const TRAY_TOOLTIP: &str = "Rust Switcher";
 
 unsafe fn show_popup_menu_at_cursor(hwnd: HWND, hmenu: HMENU) -> u32 {
     let mut pt = POINT { x: 0, y: 0 };
@@ -125,7 +126,7 @@ unsafe fn apply_tray_identity(nid: &mut NOTIFYICONDATAW, hwnd: HWND) -> windows:
     nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP | NIF_SHOWTIP;
 
     nid.hIcon = unsafe { default_icon(hwnd) }?;
-    fill_wide(&mut nid.szTip, "RustSwitcher");
+    fill_wide(&mut nid.szTip, TRAY_TOOLTIP);
 
     Ok(())
 }
@@ -281,6 +282,7 @@ pub fn switch_tray_icon(hwnd: HWND, use_green: bool) -> windows::core::Result<()
         nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP;
         nid.uCallbackMessage = WM_APP_TRAY;
         nid.hIcon = icon;
+        fill_wide(&mut nid.szTip, TRAY_TOOLTIP);
 
         shell_notify(NIM_MODIFY, &nid, "switch_tray_icon")
     }


### PR DESCRIPTION
### Motivation
- The tray icon had no visible hover tooltip for our app and the tooltip could be lost when the tray icon was updated, so provide a consistent display name for the tray and ensure it is preserved across icon changes.

### Description
- Add a shared `TRAY_TOOLTIP = "Rust Switcher"` constant and use it to fill `NOTIFYICONDATAW.szTip` in `apply_tray_identity` so the tooltip is set on initial creation.
- Also fill `szTip` in `switch_tray_icon` so the hover tooltip is preserved when the icon is modified, and update balloon title usage to `"Rust Switcher"` in the tray balloon call.

### Testing
- Ran `cargo +nightly fmt --check` which succeeded.
- Ran `cargo +nightly clippy --all-targets --all-features -- -D warnings`, `cargo +nightly build --features debug-tracing`, and `cargo +nightly test --locked` which failed in this Linux container due to Windows-only dependencies (missing `windows` crate / platform APIs), so those failures are environment-related and expected outside Windows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8826b534833291204e2e5ee69335)