### PR TITLE
Make library crate an internal test harness and fix clippy/dead-code warnings

### DIFF
--- a/src/conversion/input.rs
+++ b/src/conversion/input.rs
@@ -57,6 +57,12 @@ impl KeySequence {
     }
 }
 
+impl Default for KeySequence {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Drop for KeySequence {
     fn drop(&mut self) {
         for vk in self.pressed.drain(..).rev() {

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -476,13 +476,6 @@ pub fn take_last_layout_run_with_suffix() -> Option<(InputRun, Vec<InputRun>)> {
     journal().lock().ok()?.take_last_layout_run_with_suffix()
 }
 
-#[cfg(windows)]
-pub fn take_last_word_with_suffix() -> Option<(String, String)> {
-    let (run, suffix_runs) = take_last_layout_run_with_suffix()?;
-    let suffix: String = suffix_runs.into_iter().map(|r| r.text).collect();
-    Some((run.text, suffix))
-}
-
 pub fn push_text(s: &str) {
     if let Ok(mut j) = journal().lock() {
         j.push_text_internal(s, LayoutTag::Unknown, RunOrigin::Programmatic);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,26 @@
 #![feature(stmt_expr_attributes)]
 
 #[cfg(windows)]
-pub mod app;
+mod app;
 
-pub mod config;
-
-#[cfg(windows)]
-pub mod conversion;
-
-pub mod domain;
+mod config;
 
 #[cfg(windows)]
-pub mod helpers;
+mod conversion;
 
-pub mod input;
-pub mod input_journal;
-
-#[cfg(windows)]
-pub mod platform;
+mod domain;
 
 #[cfg(windows)]
-pub mod utils;
+mod helpers;
+
+mod input;
+mod input_journal;
+
+#[cfg(windows)]
+mod platform;
+
+#[cfg(windows)]
+mod utils;
 
 #[cfg(test)]
 mod core_tests;
-
-#[cfg(all(test, windows))]
-mod tests;


### PR DESCRIPTION
### Motivation
- Prevent accidental export of private interfaces from the library crate and stop duplicate loading of `src/tests/*` during lib test builds.
- Satisfy lints for `clippy::new_without_default` by providing a `Default` for `KeySequence`.
- Remove a dead helper (`take_last_word_with_suffix`) that had no call sites and caused `dead_code` diagnostics.

### Description
- Converted public module declarations in `src/lib.rs` from `pub mod` to private `mod` and removed the extra `#[cfg(all(test, windows))] mod tests;` inclusion to make the crate an internal test harness only.
- Implemented `Default` for `KeySequence` in `src/conversion/input.rs` as `fn default() -> Self { Self::new() }`.
- Deleted the unused `take_last_word_with_suffix` function from `src/input/ring_buffer.rs`.
- Ran `cargo clean` as part of the verification steps to avoid toolchain/proc-macro artifact drift.

### Testing
- Ran `cargo +nightly fmt --check`, which completed successfully.
- Ran `cargo +nightly clippy --all-targets --all-features -- -D warnings`, which failed in this (Linux) environment due to many `dead_code`/unused paths that become unreachable when the crate is an internal Windows-oriented test harness; the Windows-targeted `clippy -D warnings` should be re-run on the Windows toolchain as requested.
- Ran `cargo +nightly build --features debug-tracing`, which completed successfully (warnings reported but build succeeded).
- Ran `cargo +nightly test --locked` and `cargo test --lib --tests`, and all library unit tests passed (12 tests passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f94500da48332a876867121645c8a)