### PR TITLE
Make app and config public in library crate to avoid dead_code warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![feature(stmt_expr_attributes)]
 
 #[cfg(windows)]
-mod app;
+pub mod app;
 
-mod config;
+pub mod config;
 
 #[cfg(windows)]
 mod conversion;


### PR DESCRIPTION
### Motivation
- The library crate previously declared `app` and `config` as private modules which caused many UI types in `src/app.rs` to be treated as dead code by the lib target, triggering `-D dead_code` failures during strict clippy runs.

### Description
- Changed `src/lib.rs` to export the modules as `pub mod app;` and `pub mod config;`, preserving the existing `#[cfg(windows)]` gating for `app` so UI types become part of the library's public API surface.

### Testing
- Ran `cargo +nightly fmt --check` (passed), `cargo +nightly build --features debug-tracing` (passed), and `cargo +nightly test --locked` / `cargo test --lib --tests` (all tests passed), while `cargo +nightly clippy --all-targets --all-features -- -D warnings` and `cargo clippy --all-targets -- -D warnings` still fail due to unrelated pre-existing `dead_code`/`unused_imports` warnings in `src/domain/text` and `src/input/ring_buffer.rs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fa4f5c11483328bf8b0d6b64491a7)