### PR TITLE
Minimize library target, re-export core and decouple Windows ring_buffer keyboard checks

### DIFF
--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -6,10 +6,9 @@ use std::{
 #[cfg(windows)]
 use windows::Win32::UI::{
     Input::KeyboardAndMouse::{
-        GetAsyncKeyState, GetKeyboardLayout, GetKeyboardState, HKL, MOD_ALT, MOD_CONTROL,
-        ToUnicodeEx, VIRTUAL_KEY, VK_BACK, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME,
-        VK_INSERT, VK_LEFT, VK_LSHIFT, VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_RSHIFT, VK_SHIFT,
-        VK_TAB, VK_UP,
+        GetAsyncKeyState, GetKeyboardLayout, GetKeyboardState, HKL, ToUnicodeEx, VIRTUAL_KEY,
+        VK_BACK, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME, VK_INSERT, VK_LEFT, VK_LSHIFT,
+        VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_RSHIFT, VK_SHIFT, VK_TAB, VK_UP,
     },
     WindowsAndMessaging::{
         GetForegroundWindow, GetWindowThreadProcessId, KBDLLHOOKSTRUCT, LLKHF_INJECTED,
@@ -323,8 +322,11 @@ pub fn last_token_autoconverted() -> bool {
 
 #[cfg(windows)]
 fn mods_ctrl_or_alt_down() -> bool {
-    let mods = crate::platform::win::keyboard::mods::mods_now();
-    (mods & (MOD_CONTROL.0 | MOD_ALT.0)) != 0
+    // Keep this module independent from `crate::platform` so it can be built from the minimal lib target.
+    // VK_CONTROL = 0x11, VK_MENU (Alt) = 0x12.
+    let ctrl = unsafe { GetAsyncKeyState(0x11) }.cast_unsigned();
+    let alt = unsafe { GetAsyncKeyState(0x12) }.cast_unsigned();
+    (ctrl & 0x8000) != 0 || (alt & 0x8000) != 0
 }
 
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,31 @@
-#![feature(stmt_expr_attributes)]
+// Library target is intentionally minimal and cross-platform.
+//
+// The Windows application lives in `src/main.rs` and declares its own module tree.
+// If we compile the Windows app modules here, `cargo check` / `cargo clippy --all-targets`
+// will build the library target first and hit `dead_code` cascades under `-D warnings`.
+//
+// The only code that belongs in the shared library right now is `rust-switcher-core`.
 
-#[cfg(windows)]
-pub mod app;
+pub use rust_switcher_core as core;
 
-pub mod config;
+// Compatibility shim for existing unit tests that still refer to
+// `crate::domain::text::mapping::*`.
+pub mod domain {
+    pub mod text {
+        pub mod mapping {
+            pub use rust_switcher_core::text::mapping::*;
+        }
+    }
+}
 
-#[cfg(windows)]
-mod conversion;
+#[path = "input/ring_buffer.rs"]
+pub mod ring_buffer;
 
-mod domain;
-
-#[cfg(windows)]
-mod helpers;
-
-mod input;
-mod input_journal;
-
-#[cfg(windows)]
-mod platform;
-
-#[cfg(windows)]
-mod utils;
+// Compatibility shim for unit tests that still refer to
+// `crate::input::ring_buffer::*`.
+pub mod input {
+    pub use super::ring_buffer;
+}
 
 #[cfg(test)]
 mod core_tests;


### PR DESCRIPTION
### Motivation
- Prevent building Windows-only application modules as part of the library target to avoid `dead_code`/warning cascades and keep the library minimal and cross-platform.
- Maintain compatibility for existing unit tests and callers by providing shims for commonly referenced modules while moving real implementation into `rust_switcher_core`.
- Make the Windows `ring_buffer` module independent from `crate::platform` so it can be compiled from the minimal lib target.

### Description
- Replace the previous monolithic `lib.rs` with a minimal library that `pub use`s `rust_switcher_core` as `core` and adds compatibility shims for `domain::text::mapping` and `input::ring_buffer`.
- Move `ring_buffer` to be declared from `src/input/ring_buffer.rs` in the library and retain a compatibility `input` module that re-exports it.
- In `src/input/ring_buffer.rs` clean up Windows imports and remove reliance on `crate::platform::win::keyboard::mods::mods_now()` by implementing `mods_ctrl_or_alt_down` using `GetAsyncKeyState` with hardcoded VK codes and unsigned-state checks.
- Tidy a few platform-specific helper closures (`async_down` and `apply_async_key`) and add a comment explaining the independence goal.

### Testing
- Ran `cargo test` for the library target and existing unit tests and they completed successfully.
- Ran `cargo check` to validate the minimal library build and it completed successfully.
- Ran `cargo clippy --all-targets` to ensure no new lints are triggered and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fc00eea28833288e6e5fe9548c4a0)