### PR TITLE
Fix -D warnings from unused re-exports and test-only helper

### DIFF
--- a/src/domain/text/mod.rs
+++ b/src/domain/text/mod.rs
@@ -6,6 +6,3 @@ pub mod mapping;
 
 #[cfg(windows)]
 pub use convert::{switch_keyboard_layout, wait_shift_released};
-#[cfg(windows)]
-pub use last_word::autoconvert_last_word;
-pub use mapping::{ConversionDirection, convert_ru_en_with_direction};

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -109,6 +109,7 @@ impl InputJournal {
         self.enforce_cap_chars();
     }
 
+    #[cfg(any(test, windows))]
     fn push_text_internal(&mut self, text: &str, layout: LayoutTag, origin: RunOrigin) {
         let mut segment = String::new();
         let mut segment_kind: Option<RunKind> = None;
@@ -478,6 +479,7 @@ pub fn take_last_layout_run_with_suffix() -> Option<(InputRun, Vec<InputRun>)> {
     journal().lock().ok()?.take_last_layout_run_with_suffix()
 }
 
+#[cfg(test)]
 pub fn push_text(s: &str) {
     if let Ok(mut j) = journal().lock() {
         j.push_text_internal(s, LayoutTag::Unknown, RunOrigin::Programmatic);


### PR DESCRIPTION
### Motivation
- Remove unused re-exports and guard test-only helpers that trigger `-D warnings` (`unused-imports` / `dead_code`) on non-Windows builds.
- Ensure the library and unit tests compile cleanly under strict CI linting and warning-to-error settings.

### Description
- Removed unused re-exports from `src/domain/text/mod.rs`: the `last_word::autoconvert_last_word` and `mapping::{ConversionDirection, convert_ru_en_with_direction}` re-exports were deleted.
- Added `#[cfg(test)]` to the public helper `push_text` in `src/input/ring_buffer.rs` so it is compiled only for tests.
- Added `#[cfg(any(test, windows))]` to `InputJournal::push_text_internal` so the internal method is only compiled on Windows or during tests to avoid `dead_code` on other targets.

### Testing
- Ran `cargo +nightly fmt --check` which succeeded.
- Ran `cargo +nightly clippy --all-targets --all-features -- -D warnings` which succeeded.
- Ran `cargo +nightly build --features debug-tracing` which succeeded.
- Ran `cargo +nightly test --locked` and `cargo +nightly test --lib --tests` and all unit tests passed (12 tests passed in the library crate).
- Note: Windows `cargo build` / `cargo test` were not executed in this Linux environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fdcdc070883329bfd31fc10b36475)