### PR TITLE
Fix unresolved `push_text` import in non-test builds

### DIFF
--- a/src/input_journal.rs
+++ b/src/input_journal.rs
@@ -1,5 +1,8 @@
+#[cfg(test)]
+#[allow(unused_imports)]
+pub use crate::input::ring_buffer::push_text;
 #[allow(unused_imports)]
 pub use crate::input::ring_buffer::{
     InputRun, LayoutTag, RunKind, RunOrigin, mark_last_token_autoconverted, push_run, push_runs,
-    push_text, take_last_layout_run_with_suffix,
+    take_last_layout_run_with_suffix,
 };


### PR DESCRIPTION
### Motivation
- `push_text` was made test-only in `src/input/ring_buffer.rs` but was still re-exported unconditionally from `src/input_journal.rs`, causing unresolved import errors for non-test builds.

### Description
- Restrict the `push_text` re-export in `src/input_journal.rs` to `#[cfg(test)]` and keep the other re-exports unchanged so runtime builds no longer reference the test-only symbol.

### Testing
- Ran `cargo +nightly fmt --check` which passed; ran `cargo +nightly clippy --all-targets --all-features -- -D warnings` which passed; ran `cargo +nightly build --features debug-tracing` which succeeded; and ran `cargo +nightly test --locked` with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02fd291fc8332bfc79df03aeb7a02)