### PR TITLE
Replace manual "Convert last word" with layout-aware "Convert last sequence" behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rust Switcher is a Windows 11 utility that helps convert text between RU and EN 
 ## Features
 
 - Convert selected text (RU-EN)
-- Convert the last typed word via a hotkey
+- Convert the last typed sequence via a hotkey
 - Auto-convert the last word while typing (can be paused)
 - Tray icon and quick actions menu
 - Light and dark UI themes

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -85,7 +85,7 @@ This is the primary conversion action.
 
 Behavior:
 - If there is a non empty selection, it converts the selection.
-- Otherwise it converts last word using the input journal.
+- Otherwise it converts last sequence using the input journal.
 
 ### Convert selection
 
@@ -100,10 +100,10 @@ Algorithm (src/domain/text/convert.rs and clipboard helper module):
 
 This intentionally avoids paste via Ctrl+V to reduce interference with application specific paste behavior.
 
-### Convert last word
+### Convert last sequence
 
 Algorithm (src/domain/text/last_word.rs):
-- Uses the input journal tokenization to determine the last word.
+- Uses the input journal tokenization to determine the last sequence.
 - Sleep for autoconvert_delay_ms before conversion and replacement.
 - Applies an input based replacement strategy (backspace and Unicode injection via SendInput).
 - Clipboard is not used as the primary mechanism.

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -1,4 +1,4 @@
-pub const CONVERT_LAST_WORD: &str = "Convert last word";
+pub const CONVERT_LAST_WORD: &str = "Convert last sequence";
 pub const CONVERT_SELECTION: &str = "Convert selection";
 pub const PAUSE: &str = "Autoconvert pause";
 pub const SWITCH_LAYOUT: &str = "Switch keyboard layout";

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -3,5 +3,5 @@ pub mod input;
 
 pub use crate::domain::text::{
     convert::{convert_selection, convert_selection_if_any},
-    last_word::convert_last_word,
+    last_word::convert_last_sequence,
 };

--- a/src/input_journal.rs
+++ b/src/input_journal.rs
@@ -4,5 +4,5 @@ pub use crate::input::ring_buffer::push_text;
 #[allow(unused_imports)]
 pub use crate::input::ring_buffer::{
     InputRun, LayoutTag, RunKind, RunOrigin, mark_last_token_autoconverted, push_run, push_runs,
-    take_last_layout_run_with_suffix,
+    push_text_with_meta, take_last_layout_run_with_suffix, take_last_layout_sequence_with_suffix,
 };

--- a/src/platform/ui.rs
+++ b/src/platform/ui.rs
@@ -324,7 +324,7 @@ fn create_hotkey_rows(
         hy,
         g.w_label,
         g.w_edit,
-        w!("Convert last word:"),
+        w!("Convert last sequence:"),
         Some(ControlId::HotkeyLastWord.hmenu()),
     )?;
     hy += 28;

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -665,7 +665,7 @@ fn handle_convert_smart(state: &mut AppState) {
     if crate::conversion::convert_selection_if_any(state) {
         return;
     }
-    crate::conversion::convert_last_word(state);
+    crate::conversion::convert_last_sequence(state);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- The manual hotkey conversion should operate on the most recent contiguous sequence of physical typing in the same keyboard layout (including internal whitespace), instead of a single run/word, while keeping autoconvert semantics unchanged.
- Preserve journal tokenization when writing converted text back to the input journal so programmatic updates do not collapse Text and Whitespace runs.
- Keep config key compatibility while renaming user-facing labels from "Convert last word" to "Convert last sequence".

### Description
- Added a new manual conversion flow `convert_last_sequence()` and kept `convert_last_word()` as a backwards-compatible alias that delegates to it, and switched smart conversion to call `convert_last_sequence()` when no selection exists.
- Implemented `LastSequencePayload`, `take_last_sequence_payload()` and `convert_last_sequence_impl()` in `src/domain/text/last_word.rs`, plus `apply_last_sequence_conversion()`, `update_journal_sequence()` and `restore_journal_original_sequence()` to handle replacement and journal updates while preserving run tokenization.
- Added ring-buffer primitives `take_last_layout_sequence_with_suffix()` and `push_text_with_meta()` in `src/input/ring_buffer.rs` and re-exported them via `src/input_journal.rs` so runtime code can extract sequences and push segmented runs with explicit layout and origin.
- Updated UI and docs wording and a string constant to show "Convert last sequence" while leaving config field names untouched; updated `src/platform/ui.rs`, `src/config/constants.rs`, `README.md` and `docs/spec.md` accordingly.
- Added tests in `src/domain/text/last_word.rs` covering sequence extraction across internal whitespace and verifying that `update_journal_sequence()` preserves Text/Whitespace tokenization.

### Testing
- Ran formatting, linting, build and tests as required: `cargo +nightly fmt --check`, `cargo +nightly clippy --all-targets --all-features -- -D warnings`, `cargo +nightly build --features debug-tracing`, `cargo +nightly test --locked`, and `cargo +nightly check --target x86_64-pc-windows-msvc --locked`, and all commands completed successfully.
- Unit tests were executed via `cargo +nightly test --locked` and the suite passed (new tests included and green).
- Performed a local debug build with `cargo +nightly build --features debug-tracing` and a Windows-target check, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b623e8288332a0eec5b0dc2c63f1)