### PR TITLE
Allow programmatic-origin sequences for layout extraction and add round-trip toggle tests

### DIFF
--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -290,19 +290,11 @@ impl InputJournal {
         }
 
         let last = self.runs.back()?.clone();
-        // Convert only sequences produced by physical input to avoid re-converting injected text.
-        if last.origin != RunOrigin::Physical {
-            while let Some(run) = suffix_runs.pop() {
-                self.total_chars += run.text.chars().count();
-                self.runs.push_back(run);
-            }
-            return None;
-        }
-
         let target_layout = last.layout.clone();
+        let target_origin = last.origin;
         let mut seq_rev: Vec<InputRun> = Vec::new();
         while let Some(run) = self.runs.back() {
-            if run.layout != target_layout || run.origin != RunOrigin::Physical {
+            if run.layout != target_layout || run.origin != target_origin {
                 break;
             }
             let run = self.runs.pop_back()?;


### PR DESCRIPTION
### Motivation

- The extractor rejected non-physical runs which prevented toggling back to a programmatically-inserted conversion, causing a manual-convert -> programmatic update -> manual-convert roundtrip to fail.

### Description

- Replace the hard-coded `RunOrigin::Physical` check with a `target_origin` derived from the last run so sequences are extracted only when their origin matches the sequence head instead of always requiring `Physical`.
- Preserve existing suffix handling and sequence reversal logic while changing the origin comparison to `run.origin != target_origin` in `take_last_layout_sequence_with_suffix` in `src/input/ring_buffer.rs`.
- Add tests in `src/domain/text/last_word.rs`: `manual_sequence_can_toggle_back_via_programmatic_origin` and `manual_sequence_toggles_roundtrip_twice` to verify programmatic-origin sequences are accepted and toggling roundtrips succeed.

### Testing

- Ran the unit test suite with `cargo test` including the new tests `manual_sequence_can_toggle_back_via_programmatic_origin` and `manual_sequence_toggles_roundtrip_twice`. All tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17e6197688332bb808ab02d1bb0fe)