### PR TITLE
Harden clippy compliance and drop nightly stmt_expr_attributes dependency

### DIFF
--- a/crates/rust-switcher-core/Cargo.toml
+++ b/crates/rust-switcher-core/Cargo.toml
@@ -5,5 +5,8 @@ name = "rust-switcher-core"
 version = "1.0.4"
 edition = "2024"
 license = "MIT"
+readme = "../../README.md"
+keywords = ["windows", "keyboard", "layout", "text", "conversion"]
+categories = ["text-processing", "os::windows-apis"]
 
 [dependencies]

--- a/crates/rust-switcher-core/src/text/mapping.rs
+++ b/crates/rust-switcher-core/src/text/mapping.rs
@@ -6,15 +6,15 @@ pub enum ConversionDirection {
     EnToRu,
 }
 
-fn is_latin_letter(ch: char) -> bool {
+const fn is_latin_letter(ch: char) -> bool {
     ch.is_ascii_alphabetic()
 }
 
-fn is_cyrillic_letter(ch: char) -> bool {
+const fn is_cyrillic_letter(ch: char) -> bool {
     matches!(ch, 'А'..='Я' | 'а'..='я' | 'Ё' | 'ё')
 }
 
-fn map_ru_to_en(ch: char) -> char {
+const fn map_ru_to_en(ch: char) -> char {
     match ch {
         // punctuation rules (for . , ? keys)
         ',' => '?',
@@ -98,7 +98,7 @@ fn map_ru_to_en(ch: char) -> char {
     }
 }
 
-fn map_en_to_ru(ch: char) -> char {
+const fn map_en_to_ru(ch: char) -> char {
     match ch {
         // letters / punctuation keys (EN -> RU)
         'q' => 'й',
@@ -201,6 +201,7 @@ fn letter_counts(text: &str) -> (usize, usize) {
 /// Returns a conversion direction based on letter balance.
 ///
 /// If the counts are tied (including zero letters), returns `None`.
+#[must_use]
 pub fn conversion_direction_for_text(text: &str) -> Option<ConversionDirection> {
     let (cyr, lat) = letter_counts(text);
     match cyr.cmp(&lat) {
@@ -211,6 +212,7 @@ pub fn conversion_direction_for_text(text: &str) -> Option<ConversionDirection> 
 }
 
 /// Converts text between English QWERTY and Russian ЙЦУКЕН keyboard layouts in the given direction.
+#[must_use]
 pub fn convert_ru_en_with_direction(text: &str, direction: ConversionDirection) -> String {
     let mut out = String::with_capacity(text.len());
     match direction {
@@ -228,8 +230,9 @@ pub fn convert_ru_en_with_direction(text: &str, direction: ConversionDirection) 
     out
 }
 
-/// Convenience wrapper: auto-detect direction (fallback to RuToEn on ties).
+/// Convenience wrapper: auto-detect direction (fallback to `RuToEn` on ties).
 /// This is intentionally a normal public API so downstream test crates can use it.
+#[must_use]
 pub fn convert_ru_en_bidirectional(text: &str) -> String {
     let direction = conversion_direction_for_text(text).unwrap_or(ConversionDirection::RuToEn);
     convert_ru_en_with_direction(text, direction)

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -65,7 +65,7 @@ struct InputJournal {
 }
 
 impl InputJournal {
-    fn new(cap_chars: usize) -> Self {
+    const fn new(cap_chars: usize) -> Self {
         Self {
             runs: VecDeque::new(),
             cap_chars,
@@ -360,6 +360,7 @@ pub fn mark_last_token_autoconverted() {
 }
 
 #[cfg(any(test, windows))]
+#[must_use]
 pub fn last_token_autoconverted() -> bool {
     journal()
         .lock()
@@ -521,10 +522,12 @@ pub fn record_keydown(kb: &KBDLLHOOKSTRUCT, vk: u32) -> Option<String> {
     output
 }
 
+#[must_use]
 pub fn take_last_layout_run_with_suffix() -> Option<(InputRun, Vec<InputRun>)> {
     journal().lock().ok()?.take_last_layout_run_with_suffix()
 }
 
+#[must_use]
 pub fn take_last_layout_sequence_with_suffix() -> Option<(Vec<InputRun>, Vec<InputRun>)> {
     journal()
         .lock()
@@ -581,6 +584,7 @@ pub fn invalidate() {
 }
 
 #[cfg(any(test, windows))]
+#[must_use]
 pub fn last_char_triggers_autoconvert() -> bool {
     let Ok(j) = journal().lock() else {
         return false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::multiple_crate_versions,
+    reason = "The binary integrates Win32 and NLP crates that currently pull parallel transitive major versions."
+)]
+
 // Library target is intentionally minimal and cross-platform.
 //
 // The Windows application lives in `src/main.rs` and declares its own module tree.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
+#![allow(
+    clippy::multiple_crate_versions,
+    reason = "The Windows stack and language-detection dependencies currently require parallel transitive versions."
+)]
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![feature(stmt_expr_attributes)]
 
 #[cfg(windows)]
 mod app;

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -325,11 +325,24 @@ fn on_create(hwnd: HWND) -> LRESULT {
     state.hotkey_values = crate::app::HotkeyValues::from_config(&cfg);
     state.active_hotkey_sequences = crate::app::HotkeySequenceValues::from_config(&cfg);
 
-    #[rustfmt::skip] {
-        startup_or_return0!(hwnd, &mut state, "Failed to apply config to UI", apply_config_to_ui(state.as_mut(), &cfg));
-        startup_or_return0!(hwnd, &mut state, "Failed to read autostart state", refresh_autostart_checkbox(state.as_mut()));
-        startup_or_return0!(hwnd, &mut state, "Failed to apply config at runtime", apply_config_runtime(hwnd, state.as_mut(), &cfg));
-    }
+    startup_or_return0!(
+        hwnd,
+        &mut state,
+        "Failed to apply config to UI",
+        apply_config_to_ui(state.as_mut(), &cfg)
+    );
+    startup_or_return0!(
+        hwnd,
+        &mut state,
+        "Failed to read autostart state",
+        refresh_autostart_checkbox(state.as_mut())
+    );
+    startup_or_return0!(
+        hwnd,
+        &mut state,
+        "Failed to apply config at runtime",
+        apply_config_runtime(hwnd, state.as_mut(), &cfg)
+    );
 
     keyboard::install(hwnd, state.as_mut());
     mouse::install();

--- a/src/tests/mapping_invariants_tests.rs
+++ b/src/tests/mapping_invariants_tests.rs
@@ -12,10 +12,14 @@ fn xorshift64(seed: &mut u64) -> u64 {
 }
 
 fn gen_string(seed: &mut u64, alphabet: &[char], max_len: usize) -> String {
-    let len = (xorshift64(seed) as usize) % (max_len + 1);
+    let max_len_u64 = u64::try_from(max_len).unwrap_or(u64::MAX - 1);
+    let len_u64 = xorshift64(seed) % (max_len_u64 + 1);
+    let len = usize::try_from(len_u64).unwrap_or(max_len);
     let mut out = String::with_capacity(len);
     for _ in 0..len {
-        let idx = (xorshift64(seed) as usize) % alphabet.len();
+        let alphabet_len_u64 = u64::try_from(alphabet.len()).unwrap_or(u64::MAX);
+        let idx_u64 = xorshift64(seed) % alphabet_len_u64;
+        let idx = usize::try_from(idx_u64).unwrap_or(0);
         out.push(alphabet[idx]);
     }
     out


### PR DESCRIPTION
### Motivation
- Remove an unnecessary nightly-only crate feature (`stmt_expr_attributes`) and make the workspace pass a strict Clippy profile so the project is easier to review and maintain on modern toolchains. 
- Fix pedantic/clippy findings (missing cargo metadata, `missing_const_for_fn`, `must_use` candidates, and portability casts) without changing public behaviour.
- Provide minimal, well-justified deviations where the dependency graph forces multiple crate versions.

### Description
- Removed `#![feature(stmt_expr_attributes)]` and rewrote the small expression-attributed startup block into normal statements to eliminate the nightly requirement (`src/main.rs`, `src/platform/win.rs`).
- Added missing package metadata to `crates/rust-switcher-core/Cargo.toml` (`readme`, `keywords`, `categories`) to satisfy `clippy::cargo` checks.
- Converted pure helpers and mapping functions to `const fn` where appropriate and added `#[must_use]` to conversion APIs in the core mapping module to improve correctness guarantees (`crates/rust-switcher-core/src/text/mapping.rs`).
- Made `InputJournal::new` a `const fn`, and added `#[must_use]` to several ring-buffer query functions to avoid accidental result loss (`src/input/ring_buffer.rs`).
- Replaced direct `u64 as usize` casts in a randomized test helper with checked conversions to avoid truncation warnings on 32-bit targets (`src/tests/mapping_invariants_tests.rs`).
- Added a narrowly-scoped crate-level `#[allow(clippy::multiple_crate_versions)]` with a clear reason to silence a transitive dependency duplication warning that is outside the scope of this patch (`src/lib.rs` and `src/main.rs`).

### Testing
- Ran formatting check: `cargo fmt --all -- --check` — passed.
- Ran strict clippy: `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::all -W clippy::pedantic -W clippy::nursery -W clippy::cargo -W clippy::perf` — passed after changes.
- Built and ran tests: `cargo test --workspace --all-features --all-targets` and `cargo +nightly test --locked` — all tests passed (unit tests and core tests succeeded).
- Generated docs and ran doc-tests: `cargo test --doc --workspace` and `cargo doc --workspace --no-deps` — succeeded.
- Verified nightly-toolchain checks still succeed: `cargo +nightly fmt --check`, `cargo +nightly clippy --all-targets --all-features -- -D warnings`, and `cargo +nightly build --features debug-tracing` — all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47a15df188332ad2575fec95ab698)