### PR TITLE
Refactor input journal and autoconvert logic; improve hotkey formatting and Justfile workspace commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,15 +14,15 @@ help:
 
 # Check formatting.
 fmt:
-	cargo fmt --check
+	cargo fmt --all -- --check
 
 # Run clippy with CI flags.
 clippy:
-	cargo clippy --all-targets --all-features --locked -- -D warnings
+	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
 # Run the test suite.
 test:
-	cargo test --locked
+	cargo test --workspace --all-features --all-targets --locked
 
 # Run all quality checks.
 check: fmt clippy test

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,7 +152,6 @@ pub fn load() -> io::Result<Config> {
     confy::load_path(path).map_err(confy_err)
 }
 
-#[allow(dead_code)]
 pub fn save(cfg: &Config) -> io::Result<()> {
     let path = config_path()?;
     ensure_parent_dir(&path)?;

--- a/src/config/config_validator.rs
+++ b/src/config/config_validator.rs
@@ -43,10 +43,8 @@ pub fn find_duplicate_hotkey_sequences(config: &Config) -> Option<String> {
         let mut error = String::from("Duplicate hotkey sequences found:\n\n");
 
         for (name1, name2) in &duplicates {
-            debug_assert!(
-                writeln!(error, "• '{name1}' and '{name2}'").is_ok(),
-                "writing to String must not fail"
-            );
+            // `String` implements `fmt::Write` infallibly; ignore the `fmt::Result` for clarity.
+            let _ = writeln!(error, "• '{name1}' and '{name2}'");
         }
 
         error.push_str("\nEach action must have a unique hotkey sequence.");


### PR DESCRIPTION
### Motivation
- Make the input journal and autoconvert code safer, more efficient, and clearer by reducing cloning, handling mutex poisoning, and preventing reentry into autoconvert.
- Centralize and simplify suffix/run text handling and conversion application to remove duplicated logic.
- Improve hotkey string formatting and ensure modifier ordering and display are consistent.
- Update development helper commands in the `Justfile` to operate on the whole workspace and all targets/features.

### Description
- Added `with_journal` and `with_journal_mut` helpers to centralize `OnceLock<Mutex<InputJournal>>` locking and poison handling, and replaced inline lock uses with these helpers across `src/input/ring_buffer.rs`.
- Refactored `InputJournal` internals: made `LayoutTag` `Copy`, optimized `push_text_internal` to segment without intermediate allocations, and extracted `pop_suffix_whitespace`/`restore_suffix` to simplify suffix handling and avoid duplication.
- Reworked autoconvert guards and restore helpers in `src/domain/text/last_word.rs`: added `AutoconvertGuard`, `JournalRestore`, and `JournalRestoreSequence` with `#[must_use]` to prevent reentry and accidental drop-before-commit, consolidated suffix metadata collection into `suffix_text_and_meta`, and unified conversion application via `apply_conversion` to share logic between run/sequence paths.
- Improved string/character utilities: simplified `looks_like_ascii_word`, optimized `trim_tail_chars` using reverse `char_indices`, avoided unnecessary clones, and used copy semantics for `LayoutTag` where appropriate.
- Cleaned up hotkey formatting in `src/platform/win/hotkey_format.rs`: simplified ASCII key rendering, introduced ordered modifier tables for both `mods_vks` and `mods`, unified chord formatting into a single output string, and handled unknown keys consistently.
- Minor changes in `src/config/config_validator.rs` to ignore infallible `fmt::Write` results when building the duplicate-hotkey error string.
- Removed unnecessary `#[allow(dead_code)]` annotation above `save` in `src/config.rs`.
- Updated `Justfile` recipes to run formatting and checks across the workspace with all targets/features: replaced `cargo fmt --check` with `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` with `cargo clippy --workspace --all-targets --all-features`, and expanded `cargo test` to `cargo test --workspace --all-features --all-targets --locked`.

### Testing
- Ran unit tests with `cargo test --workspace --all-features --all-targets --locked` and all tests passed.
- Ran formatting and lint checks with `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a0e0809c8332ac8b68029009749a)