### PR TITLE
Refresh stale Dependabot branches before auto-merge

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -29,8 +29,8 @@ jobs:
             gh pr list \
               --state open \
               --limit 100 \
-              --json number,author,baseRefName,headRefName \
-              --jq '.[] | select(.baseRefName == "dev" and .author.login == "app/dependabot" and (.headRefName | startswith("dependabot/"))) | .number'
+              --json number,author,baseRefName,headRefName,mergeStateStatus \
+              --jq '.[] | select(.baseRefName == "dev" and .author.login == "app/dependabot" and (.headRefName | startswith("dependabot/"))) | "\(.number) \(.mergeStateStatus)"'
           )
 
           if [ "${#prs[@]}" -eq 0 ]; then
@@ -38,8 +38,13 @@ jobs:
             exit 0
           fi
 
-          for pr in "${prs[@]}"; do
+          for entry in "${prs[@]}"; do
+            read -r pr merge_state <<<"$entry"
             echo "Attempting to enable auto-merge for PR #$pr"
+            if [ "$merge_state" = "BEHIND" ]; then
+              echo "PR #$pr is behind dev; updating branch first."
+              gh pr update-branch "$pr"
+            fi
             if gh pr merge "$pr" --auto --squash --delete-branch; then
               echo "Auto-merge is enabled for PR #$pr"
             else


### PR DESCRIPTION
## Summary
Teach the scheduled Dependabot auto-merge worker to refresh stale PR branches before arming auto-merge.

## Problem
After one Dependabot PR merged, the remaining queued PRs became `BEHIND` and the first auto-merge workflow only tried `gh pr merge --auto`, which is not enough when branch protection requires up-to-date branches.

## Solution
Update `auto_merge.yml` to inspect `mergeStateStatus`, run `gh pr update-branch` for `BEHIND` same-repo Dependabot PRs, and then enable squash auto-merge.

## Scope
Included: scheduler behavior for Dependabot PR branch refreshes.
Not included: any application/runtime changes or additional release workflow changes.

## Validation
- `actionlint -color` via the official Windows binary release
- `zizmor --min-severity medium .`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`

## Risks
`gh pr update-branch` can still fail for conflicted PRs, so truly conflicted Dependabot branches will still need manual conflict resolution.