### PR TITLE
Fix release detection for merged Dependabot cargo PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,66 +49,35 @@ jobs:
               return;
             }
 
-            const query = `
-              query($owner: String!, $repo: String!, $oid: GitObjectID!) {
-                repository(owner: $owner, name: $repo) {
-                  object(oid: $oid) {
-                    ... on Commit {
-                      associatedPullRequests(first: 10) {
-                        nodes {
-                          number
-                          merged
-                          baseRefName
-                          headRefName
-                          author {
-                            login
-                          }
-                          labels(first: 20) {
-                            nodes {
-                              name
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            `;
-
-            const result = await github.graphql(query, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              oid: context.sha,
-            });
-
-            const commit = result.repository.object;
-            if (!commit) {
+            const message = context.payload.head_commit?.message ?? '';
+            const subject = message.split('\n', 1)[0] ?? '';
+            const match = subject.match(/\(#(\d+)\)$/);
+            if (!match) {
               core.setOutput('should_release', 'false');
-              core.setOutput('reason', 'no-commit');
+              core.setOutput('reason', 'no-pr-number-in-subject');
               return;
             }
 
-            const prs = commit.associatedPullRequests.nodes;
-            const pr = prs.find((candidate) => {
-              const labels = candidate.labels.nodes.map((label) => label.name);
-              return (
-                candidate.merged &&
-                candidate.baseRefName === 'dev' &&
-                candidate.author?.login === 'dependabot[bot]' &&
-                candidate.headRefName.startsWith('dependabot/') &&
-                labels.includes('rust')
-              );
+            const prNumber = Number(match[1]);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
             });
 
-            if (!pr) {
+            if (
+              !pr.merged ||
+              pr.base.ref !== 'dev' ||
+              pr.user.login !== 'dependabot[bot]' ||
+              !pr.head.ref.startsWith('dependabot/cargo/')
+            ) {
               core.setOutput('should_release', 'false');
               core.setOutput('reason', 'no-matching-pr');
               return;
             }
 
             core.setOutput('should_release', 'true');
-            core.setOutput('reason', `dependabot-pr-${pr.number}`);
+            core.setOutput('reason', `dependabot-pr-${prNumber}`);
 
       - name: Stop when this push is not a cargo Dependabot merge
         if: steps.release_context.outputs.should_release != 'true'


### PR DESCRIPTION
## Summary
Fix `Release` workflow detection so merged Dependabot cargo PRs are recognized reliably on `push` events.

## Problem
The first live cargo merge (`#89`) triggered the `Release` workflow, but the workflow skipped because the `associatedPullRequests` GraphQL lookup returned no matching PR for the merge commit SHA.

## Solution
Parse the merged PR number from the squash-merge commit subject, fetch that PR directly via the REST API, and gate the release on the PR being a merged `dependabot/cargo/*` PR into `dev`.

## Scope
Included: release-trigger detection logic only.
Not included: changes to the release script itself or application/runtime code.

## Validation
- `actionlint -color` via the official Windows binary release
- `zizmor --min-severity medium .`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`

## Risks
This detection relies on the current squash-merge commit subject format containing the PR number suffix like `(#123)`. If the merge message format changes materially, the workflow would need a corresponding update.