### PR TITLE
Repair release version rewrite

### DIFF
--- a/scripts/release/common.ps1
+++ b/scripts/release/common.ps1
@@ -201,8 +201,16 @@ function Update-DependencyVersionInCargoToml {
   $NewVersion = Assert-SemVer $NewVersion
 
   $toml = Get-Content -Path $Path -Raw -Encoding UTF8
-  $pattern = "(?m)^(\s*" + [regex]::Escape($DependencyName) + "\s*=\s*\{[^\n]*?\bversion\s*=\s*`")([^\`"]+)(`"[^\n]*\})"
-  $updated = [regex]::Replace($toml, $pattern, ('$1' + $NewVersion + '$3'), 1)
+  $pattern = "(?m)^(\s*" + [regex]::Escape($DependencyName) + "\s*=\s*\{[^\r\n]*?\bversion\s*=\s*`")([^\`"]+)(`"[^\r\n]*\})"
+  $regex = [regex]::new($pattern)
+  $updated = $regex.Replace(
+    $toml,
+    [System.Text.RegularExpressions.MatchEvaluator]{
+      param($match)
+      $match.Groups[1].Value + $NewVersion + $match.Groups[3].Value
+    },
+    1
+  )
   if ($updated -ne $toml) {
     Set-Content -Path $Path -Value $updated -Encoding UTF8
     return $true


### PR DESCRIPTION
## Summary
Fix the release helper that rewrites the local ust-switcher-core dependency version during automated bumps.

## Problem
The helper built a regex replacement string like $11.0.7, which .NET interpreted as a reference to capture group 11. That corrupted Cargo.toml, so cargo generate-lockfile failed and the release workflow stopped before tagging or publishing.

## Solution
Use an explicit regex instance and a match evaluator to rebuild the dependency line from capture groups without ambiguous replacement syntax.

## Scope
Included: the release helper fix in scripts/release/common.ps1.
Not included: any workflow logic changes or dependency PR merges.

## Validation
- cargo +nightly fmt --check
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly build --features debug-tracing
- cargo +nightly test --locked
- C:\Users\Alex Cat\AppData\Local\Temp\actionlint-1.7.12\actionlint.exe -color
- zizmor --min-severity medium .
- manual repro of the bump helper updating Cargo.toml and regenerating Cargo.lock

## Risks
The full release workflow still needs one end-to-end rerun on GitHub after this merges to confirm tag/release/publish complete successfully.