### PR TITLE
Stabilize release bump output parsing

### DIFF
--- a/scripts/release/bump.ps1
+++ b/scripts/release/bump.ps1
@@ -35,9 +35,9 @@ try {
   }
 
   # Update Cargo.lock deterministically for the new workspace versions.
-  Invoke-Checked cargo @('generate-lockfile') -Quiet
+  $null = Invoke-Checked cargo @('generate-lockfile') -Quiet
 
-  Invoke-Checked git @('add', 'Cargo.toml', 'Cargo.lock', 'crates/rust-switcher-core/Cargo.toml') -Quiet
+  $null = Invoke-Checked git @('add', 'Cargo.toml', 'Cargo.lock', 'crates/rust-switcher-core/Cargo.toml') -Quiet
   $msg = "chore: bump version to $target"
 
   $commit = Invoke-Checked git @('commit', '-m', $msg) -AllowFailure -Quiet

--- a/scripts/release/common.ps1
+++ b/scripts/release/common.ps1
@@ -201,8 +201,16 @@ function Update-DependencyVersionInCargoToml {
   $NewVersion = Assert-SemVer $NewVersion
 
   $toml = Get-Content -Path $Path -Raw -Encoding UTF8
-  $pattern = "(?m)^(\s*" + [regex]::Escape($DependencyName) + "\s*=\s*\{[^\n]*?\bversion\s*=\s*`")([^\`"]+)(`"[^\n]*\})"
-  $updated = [regex]::Replace($toml, $pattern, ('$1' + $NewVersion + '$3'), 1)
+  $pattern = "(?m)^(\s*" + [regex]::Escape($DependencyName) + "\s*=\s*\{[^\r\n]*?\bversion\s*=\s*`")([^\`"]+)(`"[^\r\n]*\})"
+  $regex = [regex]::new($pattern)
+  $updated = $regex.Replace(
+    $toml,
+    [System.Text.RegularExpressions.MatchEvaluator]{
+      param($match)
+      $match.Groups[1].Value + $NewVersion + $match.Groups[3].Value
+    },
+    1
+  )
   if ($updated -ne $toml) {
     Set-Content -Path $Path -Value $updated -Encoding UTF8
     return $true

--- a/scripts/release/release.ps1
+++ b/scripts/release/release.ps1
@@ -16,7 +16,7 @@ try {
   Assert-CleanWorktree
 
   # Ensure we see remote tags for immutability checks.
-  Invoke-Checked git @('fetch', 'origin', '--tags', '--prune') -Quiet
+  $null = Invoke-Checked git @('fetch', 'origin', '--tags', '--prune') -Quiet
 
   # Determine target version (for early tag immutability validation).
   $appCur  = Get-CargoPackageVersion 'rust-switcher'
@@ -52,7 +52,10 @@ try {
   if (-not $tagSha) {
     Write-Host "`n>> bumping version to $target"
     $newV = & pwsh -ExecutionPolicy Bypass -NoLogo -NoProfile -File "$PSScriptRoot\bump.ps1" $target
-    $newV = ($newV | Select-Object -Last 1).Trim()
+    $newV = ($newV |
+      ForEach-Object { "$_".Trim() } |
+      Where-Object { $_ } |
+      Select-Object -Last 1)
     if ($newV -ne $target) {
       throw "bump.ps1 returned '$newV' but expected '$target'"
     }
@@ -73,7 +76,7 @@ try {
   Invoke-Checked git @('push', 'origin', 'dev')
 
   # Re-fetch tags to reduce race with concurrent tag creation.
-  Invoke-Checked git @('fetch', 'origin', '--tags', '--prune') -Quiet
+  $null = Invoke-Checked git @('fetch', 'origin', '--tags', '--prune') -Quiet
 
   # Create immutable tag at HEAD (or verify existing).
   $head = (Invoke-Checked git @('rev-parse', 'HEAD') -Quiet).Output.Trim()
@@ -96,7 +99,7 @@ try {
 
   # Create/update GitHub Release and upload assets.
   Write-Host "`n>> GitHub Release $tag (create/edit + upload assets)"
-  Invoke-Checked gh @('auth', 'status') -Quiet
+  $null = Invoke-Checked gh @('auth', 'status') -Quiet
 
   $notesFile = New-TemporaryFile
   try {


### PR DESCRIPTION
## Summary
Make the release automation read the bumped version reliably and suppress quiet helper noise from the bump step.

## Problem
After the dependency-version rewrite bug was fixed, the release job still failed because ump.ps1 emitted extra quiet helper objects and a trailing blank line. elease.ps1 selected the final blank output instead of the actual version string, so it aborted even though the bump itself had succeeded.

## Solution
Suppress the unused quiet helper return values in ump.ps1 and make elease.ps1 trim and ignore blank output before selecting the returned version.

## Scope
Included: output-handling fixes in scripts/release/bump.ps1 and scripts/release/release.ps1.
Not included: workflow structure changes or unrelated dependency updates.

## Validation
- cargo +nightly fmt --check
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly build --features debug-tracing
- cargo +nightly test --locked
- C:\Users\Alex Cat\AppData\Local\Temp\actionlint-1.7.12\actionlint.exe -color
- zizmor --min-severity medium .
- local repro of ump.ps1 stdout shape showing the trailing blank output that broke elease.ps1

## Risks
The next GitHub Release run still needs end-to-end confirmation for tag creation, GitHub release upload, and crates.io publish on the hosted runner.