### PR TITLE
Avoid pushing dev during releases

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Run actionlint

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Run cargo-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)
@@ -72,7 +72,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
     env:
       CARGO_TERM_PROGRESS_WHEN: never
       GH_TOKEN: ${{ github.token }}
-      REPO_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN || github.token }}
 
     steps:
       - name: Checkout dev
@@ -92,7 +91,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git remote set-url origin "https://x-access-token:${REPO_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Reattach local dev branch
         if: steps.release_context.outputs.should_release == 'true'

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Run typos

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Run zizmor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.6"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
+checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
 dependencies = [
  "cc",
  "memchr",

--- a/scripts/release/bump.ps1
+++ b/scripts/release/bump.ps1
@@ -1,6 +1,9 @@
 param(
   [Parameter(Mandatory = $false)]
-  [string]$Version = ''
+  [string]$Version = '',
+
+  [Parameter(Mandatory = $false)]
+  [string]$SourceCommit = ''
 )
 
 . "$PSScriptRoot\common.ps1"
@@ -38,7 +41,15 @@ try {
   $null = Invoke-Checked cargo @('generate-lockfile') -Quiet
 
   $null = Invoke-Checked git @('add', 'Cargo.toml', 'Cargo.lock', 'crates/rust-switcher-core/Cargo.toml') -Quiet
-  $msg = "chore: bump version to $target"
+  $msg = if ([string]::IsNullOrWhiteSpace($SourceCommit)) {
+    "chore: bump version to $target"
+  } else {
+    @(
+      "chore: release $target",
+      "",
+      "release-source: $($SourceCommit.Trim())"
+    ) -join "`n"
+  }
 
   $commit = Invoke-Checked git @('commit', '-m', $msg) -AllowFailure -Quiet
   if ($commit.ExitCode -ne 0) {

--- a/scripts/release/common.ps1
+++ b/scripts/release/common.ps1
@@ -118,6 +118,46 @@ function Bump-Patch {
   return ("{0}.{1}.{2}" -f $p[0], $p[1], ($p[2] + 1))
 }
 
+function Get-VersionFromTag {
+  param([Parameter(Mandatory = $true)][string]$Tag)
+
+  if ($Tag -notmatch '^v(\d+\.\d+\.\d+)$') {
+    throw "Tag '$Tag' is not a release tag in the form vX.Y.Z"
+  }
+
+  return (Assert-SemVer $Matches[1])
+}
+
+function Get-LatestVersionTag {
+  $tags = (Invoke-Checked git @('tag', '--list', 'v*', '--sort=-v:refname') -Quiet).Output.Split("`n") |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { $_ -match '^v\d+\.\d+\.\d+$' }
+
+  return ($tags | Select-Object -First 1)
+}
+
+function Find-ReleaseTagForSourceCommit {
+  param([Parameter(Mandatory = $true)][string]$SourceCommit)
+
+  $needle = $SourceCommit.Trim()
+  if (-not $needle) {
+    throw 'Source commit must not be empty.'
+  }
+
+  $tags = (Invoke-Checked git @('tag', '--list', 'v*', '--sort=-v:refname') -Quiet).Output.Split("`n") |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { $_ -match '^v\d+\.\d+\.\d+$' }
+
+  foreach ($tag in $tags) {
+    $body = (Invoke-Checked git @('log', '-1', '--format=%B', $tag) -Quiet).Output
+    if ($body -match ("(?m)^release-source:\s*" + [regex]::Escape($needle) + "\s*$")) {
+      return $tag
+    }
+  }
+
+  return $null
+}
+
 function Get-CargoPackageVersion {
   param([Parameter(Mandatory = $true)][string]$Package)
 

--- a/scripts/release/release.ps1
+++ b/scripts/release/release.ps1
@@ -18,23 +18,33 @@ try {
   # Ensure we see remote tags for immutability checks.
   $null = Invoke-Checked git @('fetch', 'origin', '--tags', '--prune') -Quiet
 
+  $sourceHead = (Invoke-Checked git @('rev-parse', 'HEAD') -Quiet).Output.Trim()
+  $existingTag = Find-ReleaseTagForSourceCommit $sourceHead
+
   # Determine target version (for early tag immutability validation).
   $appCur  = Get-CargoPackageVersion 'rust-switcher'
   $coreCur = Get-CargoPackageVersion 'rust-switcher-core'
 
-  $target = if ([string]::IsNullOrWhiteSpace($Version)) {
+  $target = if ($existingTag) {
+    Get-VersionFromTag $existingTag
+  } elseif ([string]::IsNullOrWhiteSpace($Version)) {
     $base = Max-SemVer $appCur $coreCur
+    $latestTag = Get-LatestVersionTag
+    if ($latestTag) {
+      $base = Max-SemVer $base (Get-VersionFromTag $latestTag)
+    }
     Bump-Patch $base
   } else {
     Assert-SemVer $Version
   }
 
   $tag = "v$target"
-  $headBefore = (Invoke-Checked git @('rev-parse', 'HEAD') -Quiet).Output.Trim()
-
   $tagSha = Get-TagSha $tag
-  if ($tagSha -and $tagSha -ne $headBefore) {
-    throw "Tag '$tag' already exists but points to $tagSha while HEAD is $headBefore. Refusing to continue."
+  if ($existingTag -and $existingTag -ne $tag) {
+    throw "Source commit $sourceHead already maps to tag '$existingTag', but current target is '$tag'. Refusing to continue."
+  }
+  if (-not $existingTag -and $tagSha) {
+    throw "Tag '$tag' already exists but is not associated with source commit $sourceHead. Refusing to continue."
   }
 
   # Checks (must pass before version bump / release).
@@ -47,11 +57,14 @@ try {
   Write-Host "`n>> cargo test --workspace --all-features --all-targets --locked"
   Invoke-Checked cargo @('test', '--workspace', '--all-features', '--all-targets', '--locked')
 
-  # If tag already exists at HEAD, we treat the bump step as already done.
   $didBump = $false
-  if (-not $tagSha) {
+  $created = $false
+  if ($existingTag) {
+    Write-Host "`n>> reusing existing release tag $tag for source $sourceHead"
+    Invoke-Checked git @('checkout', '--detach', $tag) | Out-Null
+  } else {
     Write-Host "`n>> bumping version to $target"
-    $newV = & pwsh -ExecutionPolicy Bypass -NoLogo -NoProfile -File "$PSScriptRoot\bump.ps1" $target
+    $newV = & pwsh -ExecutionPolicy Bypass -NoLogo -NoProfile -File "$PSScriptRoot\bump.ps1" $target $sourceHead
     $newV = ($newV |
       ForEach-Object { "$_".Trim() } |
       Where-Object { $_ } |
@@ -60,30 +73,22 @@ try {
       throw "bump.ps1 returned '$newV' but expected '$target'"
     }
     $didBump = $true
-  } else {
-    # Sanity: tag points to HEAD; versions must match target.
-    $appNow  = Get-CargoPackageVersion 'rust-switcher'
-    $coreNow = Get-CargoPackageVersion 'rust-switcher-core'
-    if ($appNow -ne $target -or $coreNow -ne $target) {
-      throw "Tag '$tag' points to HEAD but Cargo.toml versions are app=$appNow core=$coreNow (expected $target). Refusing to proceed."
-    }
+
+    Assert-CleanWorktree
+
+    $head = (Invoke-Checked git @('rev-parse', 'HEAD') -Quiet).Output.Trim()
+    $created = Ensure-Tag-Immutable -Tag $tag -ExpectedSha $head
+
+    Write-Host "`n>> git push origin $tag"
+    Invoke-Checked git @('push', 'origin', $tag)
   }
 
-  Assert-CleanWorktree
-
-  # Push dev (normal push only).
-  Write-Host "`n>> git push origin dev"
-  Invoke-Checked git @('push', 'origin', 'dev')
-
-  # Re-fetch tags to reduce race with concurrent tag creation.
-  $null = Invoke-Checked git @('fetch', 'origin', '--tags', '--prune') -Quiet
-
-  # Create immutable tag at HEAD (or verify existing).
   $head = (Invoke-Checked git @('rev-parse', 'HEAD') -Quiet).Output.Trim()
-  $created = Ensure-Tag-Immutable -Tag $tag -ExpectedSha $head
-
-  Write-Host "`n>> git push origin $tag"
-  Invoke-Checked git @('push', 'origin', $tag)
+  $appNow  = Get-CargoPackageVersion 'rust-switcher'
+  $coreNow = Get-CargoPackageVersion 'rust-switcher-core'
+  if ($appNow -ne $target -or $coreNow -ne $target) {
+    throw "Release tree versions are app=$appNow core=$coreNow (expected $target). Refusing to proceed."
+  }
 
   # Build artifacts.
   Write-Host "`n>> cargo build --release"
@@ -126,9 +131,9 @@ try {
 
     $view = Invoke-Checked gh @('release', 'view', $tag) -AllowFailure -Quiet
     if ($view.ExitCode -ne 0) {
-      Invoke-Checked gh @('release', 'create', $tag, '--title', $tag, '--notes-file', $notesFile, '--target', 'dev', '--verify-tag')
+      Invoke-Checked gh @('release', 'create', $tag, '--title', $tag, '--notes-file', $notesFile, '--verify-tag')
     } else {
-      Invoke-Checked gh @('release', 'edit', $tag, '--title', $tag, '--notes-file', $notesFile, '--target', 'dev', '--verify-tag')
+      Invoke-Checked gh @('release', 'edit', $tag, '--title', $tag, '--notes-file', $notesFile)
     }
 
     $uploadArgs = @('release', 'upload', $tag) + $assets + @('--clobber')
@@ -150,7 +155,8 @@ try {
   Write-Host ("  tag:     {0}" -f $tag)
   Write-Host ("  head:    {0}" -f $sha)
   if ($releaseUrl) { Write-Host ("  release: {0}" -f $releaseUrl) }
-  if ($didBump) { Write-Host "  bump:    committed + pushed" }
+  if ($didBump) { Write-Host "  bump:    committed locally + tagged" }
+  if ($existingTag) { Write-Host "  retry:   reused existing release tag" }
   if ($created) { Write-Host "  tag:     created" } else { Write-Host "  tag:     already existed" }
 }
 finally {


### PR DESCRIPTION
## Summary
Change the automated release flow so GitHub Actions never pushes the version-bump commit back to protected dev.

## Problem
The existing release automation fixed several earlier script bugs, but still failed at git push origin dev because the workflow created a bump commit and tried to push it into protected dev. That required an extra bypass-capable GitHub token and kept the publish path dependent on branch-protection exemptions.

## Solution
Create the release version bump as a local release commit, tag that commit, and push only the tag. The workflow now publishes from the tagged release tree instead of trying to update dev from CI.

The release scripts also now:
- derive the next version from the greater of workspace versions and the latest release tag
- stamp the local release commit with elease-source: <dev-sha>
- detect and reuse an existing release tag for the same dev source commit so reruns stay idempotent
- create or edit the GitHub release directly from the tag without targeting dev

## Scope
Included:
- .github/workflows/release.yml
- scripts/release/common.ps1
- scripts/release/bump.ps1
- scripts/release/release.ps1

Not included:
- changes to the actual published crate contents beyond the temporary tagged release commit
- any branch-protection changes or extra repository secrets

## Validation
- cargo +nightly fmt --check
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly build --features debug-tracing
- cargo +nightly test --locked
- C:\Users\Alex Cat\AppData\Local\Temp\actionlint-1.7.12\actionlint.exe -color
- zizmor --min-severity medium .

## Risks
I did not complete an end-to-end GitHub Actions publish in this branch before opening the PR, so the remaining uncertainty is limited to hosted-run behavior around pushing a tag that points to a release-only commit and the subsequent GitHub release/crates publish steps.