### PR TITLE
Fix release publish script parsing

### DIFF
--- a/scripts/release/cargo_publish.ps1
+++ b/scripts/release/cargo_publish.ps1
@@ -17,7 +17,7 @@ try {
 
     $t = $r.Output
     if ($t -match 'already uploaded|is already uploaded|already exists|is already in the index|has already been published|already published') {
-      Write-Host "cargo publish -p $Package: already published; treating as success."
+      Write-Host "cargo publish -p ${Package}: already published; treating as success."
       return
     }
     throw "cargo publish -p $Package failed.`n$t"
@@ -37,7 +37,7 @@ try {
 
       $t = $r.Output
       if ($t -match 'already uploaded|is already uploaded|already exists|is already in the index|has already been published|already published') {
-        Write-Host "cargo publish -p $Package: already published; treating as success."
+        Write-Host "cargo publish -p ${Package}: already published; treating as success."
         return
       }
 


### PR DESCRIPTION
## Summary
Fix the PowerShell release publish helper so already-published crates are handled without a parser error.

## Problem
The Release workflow reached scripts/release/cargo_publish.ps1, but PowerShell rejected log strings that interpolated $Package:. That stopped the workflow after tag push and GitHub release creation.

## Solution
Use ${Package} in the two already-published log messages so PowerShell parses the script correctly and the existing success handling can run.

## Scope
Included: the narrow cargo_publish.ps1 fix only.
Not included: broader release flow changes, which were already merged in #102.

## Validation
- cargo +nightly fmt --check
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly build --features debug-tracing
- cargo +nightly test --locked
- C:\Users\Alex Cat\AppData\Local\Temp\actionlint-1.7.12\actionlint.exe -color
- zizmor --min-severity medium .
- PowerShell parser check for scripts/release/cargo_publish.ps1

## Risks
This fixes the parser failure that blocked publish, but the first rerun is still needed to prove the remaining crates.io publish path end-to-end.