### PR TITLE
Update rust-cache workflow pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: nightly
           components: rustfmt
       - name: Rust cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - name: Cargo fmt
         run: cargo +nightly fmt --all -- --check
 
@@ -46,7 +46,7 @@ jobs:
           toolchain: nightly
           components: clippy
       - name: Rust cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - name: Cargo clippy (core lib/tests only)
         run: cargo +nightly clippy --lib --tests -- -D warnings
 
@@ -63,7 +63,7 @@ jobs:
         with:
           toolchain: nightly
       - name: Rust cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - name: Cargo test (core lib/tests only)
         run: cargo +nightly test --lib --tests --locked
 
@@ -81,7 +81,7 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
       - name: Rust cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - name: Cargo fmt --check
         run: cargo +nightly fmt --check
       - name: Cargo clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: nightly
           components: rustfmt
       - name: Rust cache
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Cargo fmt
         run: cargo +nightly fmt --all -- --check
 
@@ -46,7 +46,7 @@ jobs:
           toolchain: nightly
           components: clippy
       - name: Rust cache
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Cargo clippy (core lib/tests only)
         run: cargo +nightly clippy --lib --tests -- -D warnings
 
@@ -63,7 +63,7 @@ jobs:
         with:
           toolchain: nightly
       - name: Rust cache
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Cargo test (core lib/tests only)
         run: cargo +nightly test --lib --tests --locked
 
@@ -81,7 +81,7 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
       - name: Rust cache
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Cargo fmt --check
         run: cargo +nightly fmt --check
       - name: Cargo clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Rust cache
         if: steps.release_context.outputs.should_release == 'true'
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
       - name: Authenticate to crates.io with trusted publishing
         if: steps.release_context.outputs.should_release == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Rust cache
         if: steps.release_context.outputs.should_release == 'true'
-        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Authenticate to crates.io with trusted publishing
         if: steps.release_context.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary
Update the pinned Swatinem/rust-cache action to the current 2.9.1 commit.

## Problem
The repository workflows were still pinned to an older ust-cache revision that triggers GitHub's Node.js 20 deprecation warning.

## Solution
Replace the existing Swatinem/rust-cache SHA in CI and release workflows with the latest 2.9.1 commit, keeping the workflows pinned to an immutable revision while moving to a Node 24-compatible action version.

## Scope
Included: workflow pin updates in CI and release.
Not included: broader branch protection or repository settings changes.

## Validation
- cargo +nightly fmt --check
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly build --features debug-tracing
- cargo +nightly test --locked
- C:\Users\Alex Cat\AppData\Local\Temp\actionlint-1.7.12\actionlint.exe -color
- zizmor --min-severity medium .
- Verified latest upstream Swatinem/rust-cache release metadata via GitHub API (2.9.1)

## Risks
This only addresses the deprecation warning for ust-cache. Other workflow behavior is intentionally unchanged.