### PR TITLE
Update time to patched release for RustSec #92

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -696,9 +696,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary
Update the locked `time` dependency to the patched release required by RustSec issue #92.

## Problem
The lockfile pinned `time` to `0.3.46`, which is affected by `RUSTSEC-2026-0009` (stack exhaustion in RFC 2822 parsing).

## Solution
Bump the resolved `time` crate to `0.3.47` and the paired `time-macros` crate to `0.2.27` in `Cargo.lock`.

## Scope
Included:
- lockfile-only dependency update for the vulnerable `time` crate

Not included:
- source changes
- broader dependency refresh

## Validation
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`
- `actionlint -color`
- `zizmor --min-severity medium .`

## Risks
This change is intentionally narrow and depends on compatibility of the patched transitive release with the existing dependency graph.