### PR TITLE
Harden Dependabot auto-merge policy

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -26,13 +26,35 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          should_auto_merge() {
+            local head_ref="$1"
+            local title="$2"
+
+            if [[ "$head_ref" == dependabot/cargo/* ]]; then
+              return 0
+            fi
+
+            if [[ "$head_ref" != dependabot/github_actions/* ]]; then
+              return 1
+            fi
+
+            if [[ "$title" =~ from[[:space:]]v?([0-9]+)(\.[^[:space:]]*)?[[:space:]]to[[:space:]]v?([0-9]+)(\.[^[:space:]]*)?$ ]]; then
+              if [[ "${BASH_REMATCH[1]}" != "${BASH_REMATCH[3]}" ]]; then
+                return 1
+              fi
+            fi
+
+            return 0
+          }
+
           mapfile -t prs < <(
             gh pr list \
               --repo "$GH_REPO" \
               --state open \
               --limit 100 \
-              --json number,author,baseRefName,headRefName,mergeStateStatus \
-              --jq '.[] | select(.baseRefName == "dev" and .author.login == "app/dependabot" and (.headRefName | startswith("dependabot/"))) | "\(.number) \(.mergeStateStatus)"'
+              --json number,title,author,baseRefName,headRefName,mergeStateStatus \
+              --jq '.[] | select(.baseRefName == "dev" and .author.login == "app/dependabot" and (.headRefName | startswith("dependabot/"))) | [.number, .mergeStateStatus, .headRefName, (.title | @base64)] | @tsv'
           )
 
           if [ "${#prs[@]}" -eq 0 ]; then
@@ -41,8 +63,15 @@ jobs:
           fi
 
           for entry in "${prs[@]}"; do
-            read -r pr merge_state <<<"$entry"
-            echo "Attempting to enable auto-merge for PR #$pr"
+            IFS=$'\t' read -r pr merge_state head_ref title_b64 <<<"$entry"
+            title="$(printf '%s' "$title_b64" | base64 --decode)"
+
+            if ! should_auto_merge "$head_ref" "$title"; then
+              echo "Skipping PR #$pr ($title): auto-merge policy requires cargo updates or non-major GitHub Actions bumps."
+              continue
+            fi
+
+            echo "Attempting to enable auto-merge for PR #$pr ($title)"
             if [ "$merge_state" = "BEHIND" ]; then
               echo "PR #$pr is behind dev; updating branch first."
               gh pr update-branch "$pr" --repo "$GH_REPO"

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
+      GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
 
     steps:
@@ -27,6 +28,7 @@ jobs:
           set -euo pipefail
           mapfile -t prs < <(
             gh pr list \
+              --repo "$GH_REPO" \
               --state open \
               --limit 100 \
               --json number,author,baseRefName,headRefName,mergeStateStatus \
@@ -43,9 +45,9 @@ jobs:
             echo "Attempting to enable auto-merge for PR #$pr"
             if [ "$merge_state" = "BEHIND" ]; then
               echo "PR #$pr is behind dev; updating branch first."
-              gh pr update-branch "$pr"
+              gh pr update-branch "$pr" --repo "$GH_REPO"
             fi
-            if gh pr merge "$pr" --auto --squash --delete-branch; then
+            if gh pr merge "$pr" --repo "$GH_REPO" --auto --squash --delete-branch; then
               echo "Auto-merge is enabled for PR #$pr"
             else
               echo "PR #$pr is not ready for auto-merge yet; leaving it open for the next scan."


### PR DESCRIPTION
## Summary
Fix the scheduled Dependabot auto-merge workflow so GitHub CLI commands always target the repository explicitly, and restrict automatic merges to low-risk dependency updates.

## Problem
The scheduled `Auto merge` workflow ran without a checked out git repository, but called `gh pr list` without `--repo`. In Actions this produced `fatal: not a git repository`, after which the job incorrectly reported `No open Dependabot PRs found.` As a result, Dependabot PRs stayed behind `dev` and never progressed to auto-merge.

The workflow also had no policy boundary: once fixed, it would have auto-merged any Dependabot update, including semver-major GitHub Actions bumps that deserve manual review.

## Solution
Add `GH_REPO: ${{ github.repository }}` to the job environment and pass `--repo "$GH_REPO"` to `gh pr list`, `gh pr update-branch`, and `gh pr merge`.

Then narrow the automation policy:
- allow `dependabot/cargo/*`
- allow `dependabot/github_actions/*` when the PR title does not indicate a semver-major bump
- skip obvious semver-major GitHub Actions bumps while leaving SHA-pinned and non-major action updates eligible for automatic rebase and auto-merge

## Scope
Included:
- repo-scoped GitHub CLI calls in `.github/workflows/auto_merge.yml`
- safe auto-merge policy for Dependabot PRs

Not included:
- changes to merge requirements or branch protection
- changes to release workflow behavior
- changes to Dependabot scheduling

## Validation
- `actionlint -color`
- `zizmor --min-severity medium .`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`
- manual `gh pr list --repo qqrm/rust-switcher-rs ...` verification that open Dependabot PRs are discoverable with explicit repo scoping and expose enough metadata for policy filtering

## Risks
The major-bump detection intentionally relies on Dependabot PR title format. If that title format changes materially, the policy may become more permissive or more conservative than intended until adjusted.
