### PR TITLE
Respect Caps Lock state during text capture

### DIFF
--- a/src/domain/text/last_word.rs
+++ b/src/domain/text/last_word.rs
@@ -951,6 +951,64 @@ mod tests {
     }
 
     #[test]
+    fn manual_sequence_toggles_roundtrip_for_capslock_style_uppercase_text() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_run(InputRun {
+            text: "GHBDTN".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        });
+
+        let p1 = take_last_sequence_payload().expect("first sequence payload expected");
+        assert_eq!(p1.seq_text, "GHBDTN");
+        let c1 = convert_with_layout_fallback(&p1.seq_text, &p1.layout);
+        assert_eq!(c1, "ПРИВЕТ");
+        update_journal_sequence(&p1, &c1);
+
+        let p2 = take_last_sequence_payload().expect("second sequence payload expected");
+        assert_eq!(p2.layout, LayoutTag::Ru);
+        assert_eq!(p2.seq_text, "ПРИВЕТ");
+        let c2 = convert_with_layout_fallback(&p2.seq_text, &p2.layout);
+        assert_eq!(c2, "GHBDTN");
+        update_journal_sequence(&p2, &c2);
+
+        let p3 = take_last_sequence_payload().expect("third sequence payload expected");
+        assert_eq!(p3.layout, LayoutTag::En);
+        assert_eq!(p3.seq_text, "GHBDTN");
+    }
+
+    #[test]
+    fn manual_sequence_toggles_roundtrip_for_shifted_capslock_style_lowercase_text() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_run(InputRun {
+            text: "ghbdtn".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        });
+
+        let p1 = take_last_sequence_payload().expect("first sequence payload expected");
+        assert_eq!(p1.seq_text, "ghbdtn");
+        let c1 = convert_with_layout_fallback(&p1.seq_text, &p1.layout);
+        assert_eq!(c1, "привет");
+        update_journal_sequence(&p1, &c1);
+
+        let p2 = take_last_sequence_payload().expect("second sequence payload expected");
+        assert_eq!(p2.layout, LayoutTag::Ru);
+        assert_eq!(p2.seq_text, "привет");
+        let c2 = convert_with_layout_fallback(&p2.seq_text, &p2.layout);
+        assert_eq!(c2, "ghbdtn");
+        update_journal_sequence(&p2, &c2);
+
+        let p3 = take_last_sequence_payload().expect("third sequence payload expected");
+        assert_eq!(p3.layout, LayoutTag::En);
+        assert_eq!(p3.seq_text, "ghbdtn");
+    }
+
+    #[test]
     fn update_journal_sequence_preserves_whitespace_tokenization() {
         let _guard = test_lock();
         ring_buffer::invalidate();

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -6,9 +6,10 @@ use std::{
 #[cfg(windows)]
 use windows::Win32::UI::{
     Input::KeyboardAndMouse::{
-        GetAsyncKeyState, GetKeyboardLayout, GetKeyboardState, HKL, ToUnicodeEx, VIRTUAL_KEY,
-        VK_BACK, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME, VK_INSERT, VK_LEFT, VK_LSHIFT,
-        VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_RSHIFT, VK_SHIFT, VK_TAB, VK_UP,
+        GetAsyncKeyState, GetKeyState, GetKeyboardLayout, GetKeyboardState, HKL, ToUnicodeEx,
+        VIRTUAL_KEY, VK_BACK, VK_CAPITAL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME,
+        VK_INSERT, VK_LEFT, VK_LSHIFT, VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_RSHIFT, VK_SHIFT,
+        VK_TAB, VK_UP,
     },
     WindowsAndMessaging::{
         GetForegroundWindow, GetWindowThreadProcessId, KBDLLHOOKSTRUCT, LLKHF_INJECTED,
@@ -352,6 +353,15 @@ struct DecodedText {
 }
 
 #[cfg(windows)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct KeyboardStateOverrides {
+    shift_down: bool,
+    left_shift_down: bool,
+    right_shift_down: bool,
+    caps_lock_on: bool,
+}
+
+#[cfg(windows)]
 pub fn layout_tag_from_hkl(hkl: HKL) -> LayoutTag {
     let hkl_raw = hkl.0 as usize;
 
@@ -401,6 +411,67 @@ fn mods_ctrl_or_alt_down() -> bool {
 }
 
 #[cfg(windows)]
+fn key_is_down(vk: VIRTUAL_KEY) -> bool {
+    let value = unsafe { GetAsyncKeyState(i32::from(vk.0)) }.cast_unsigned();
+    (value & 0x8000) != 0
+}
+
+#[cfg(windows)]
+fn key_is_toggled(vk: VIRTUAL_KEY) -> bool {
+    let value = unsafe { GetKeyState(i32::from(vk.0)) }.cast_unsigned();
+    (value & 0x0001) != 0
+}
+
+#[cfg(windows)]
+fn set_key_down_state(state: &mut [u8; 256], vk: VIRTUAL_KEY, is_down: bool) {
+    let idx = usize::from(vk.0);
+    if idx >= state.len() {
+        return;
+    }
+
+    if is_down {
+        state[idx] |= 0x80;
+    } else {
+        state[idx] &= !0x80;
+    }
+}
+
+#[cfg(windows)]
+fn set_key_toggle_state(state: &mut [u8; 256], vk: VIRTUAL_KEY, is_toggled: bool) {
+    let idx = usize::from(vk.0);
+    if idx >= state.len() {
+        return;
+    }
+
+    if is_toggled {
+        state[idx] |= 0x01;
+    } else {
+        state[idx] &= !0x01;
+    }
+}
+
+#[cfg(windows)]
+fn current_keyboard_state_overrides() -> KeyboardStateOverrides {
+    KeyboardStateOverrides {
+        shift_down: key_is_down(VK_SHIFT),
+        left_shift_down: key_is_down(VK_LSHIFT),
+        right_shift_down: key_is_down(VK_RSHIFT),
+        caps_lock_on: key_is_toggled(VK_CAPITAL),
+    }
+}
+
+#[cfg(windows)]
+fn apply_keyboard_state_overrides(state: &mut [u8; 256], overrides: KeyboardStateOverrides) {
+    // LL-hook decoding runs before the target thread's keyboard state is fully reflected in our
+    // thread-local `GetKeyboardState` snapshot. Patch in the physical modifier/toggle state that
+    // affects character case before calling `ToUnicodeEx`.
+    set_key_down_state(state, VK_SHIFT, overrides.shift_down);
+    set_key_down_state(state, VK_LSHIFT, overrides.left_shift_down);
+    set_key_down_state(state, VK_RSHIFT, overrides.right_shift_down);
+    set_key_toggle_state(state, VK_CAPITAL, overrides.caps_lock_on);
+}
+
+#[cfg(windows)]
 fn decode_typed_text(kb: &KBDLLHOOKSTRUCT, vk: VIRTUAL_KEY) -> Option<DecodedText> {
     let fg = unsafe { GetForegroundWindow() };
     if fg.0.is_null() {
@@ -416,27 +487,7 @@ fn decode_typed_text(kb: &KBDLLHOOKSTRUCT, vk: VIRTUAL_KEY) -> Option<DecodedTex
         return None;
     }
 
-    let async_down = |vk: VIRTUAL_KEY| -> bool {
-        let v = unsafe { GetAsyncKeyState(i32::from(vk.0)) }.cast_unsigned();
-        (v & 0x8000) != 0
-    };
-
-    let apply_async_key = |state: &mut [u8; 256], vk: VIRTUAL_KEY| {
-        let idx = usize::from(vk.0);
-        if idx >= state.len() {
-            return;
-        }
-
-        if async_down(vk) {
-            state[idx] |= 0x80;
-        } else {
-            state[idx] &= !0x80;
-        }
-    };
-
-    apply_async_key(&mut state, VK_SHIFT);
-    apply_async_key(&mut state, VK_LSHIFT);
-    apply_async_key(&mut state, VK_RSHIFT);
+    apply_keyboard_state_overrides(&mut state, current_keyboard_state_overrides());
 
     let mut buf = [0u16; 8];
     let rc = unsafe { ToUnicodeEx(u32::from(vk.0), kb.scanCode, &state, &mut buf, 0, Some(hkl)) };
@@ -610,4 +661,46 @@ pub fn last_char_triggers_autoconvert() -> bool {
 
         false
     })
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyboard_state_overrides_apply_caps_lock_toggle_without_touching_high_bit() {
+        let mut state = [0u8; 256];
+        apply_keyboard_state_overrides(
+            &mut state,
+            KeyboardStateOverrides {
+                shift_down: false,
+                left_shift_down: false,
+                right_shift_down: false,
+                caps_lock_on: true,
+            },
+        );
+
+        let caps = state[usize::from(VK_CAPITAL.0)];
+        assert_eq!(caps & 0x01, 0x01);
+        assert_eq!(caps & 0x80, 0x00);
+    }
+
+    #[test]
+    fn keyboard_state_overrides_preserve_shift_and_caps_lock_combination() {
+        let mut state = [0u8; 256];
+        apply_keyboard_state_overrides(
+            &mut state,
+            KeyboardStateOverrides {
+                shift_down: true,
+                left_shift_down: true,
+                right_shift_down: false,
+                caps_lock_on: true,
+            },
+        );
+
+        assert_eq!(state[usize::from(VK_SHIFT.0)] & 0x80, 0x80);
+        assert_eq!(state[usize::from(VK_LSHIFT.0)] & 0x80, 0x80);
+        assert_eq!(state[usize::from(VK_RSHIFT.0)] & 0x80, 0x00);
+        assert_eq!(state[usize::from(VK_CAPITAL.0)] & 0x01, 0x01);
+    }
 }


### PR DESCRIPTION
## Summary
Fix low-level text capture so journal decoding respects Caps Lock toggle state as well as Shift state, and add regression tests for caps-lock-driven case round-trips.

## Problem
The keyboard hook patched GetKeyboardState with live Shift state before calling ToUnicodeEx, but it did not patch the Caps Lock toggle bit. That let the input journal observe a different case than the user actually typed, which then broke manual conversion/toggle flows for Caps Lock and Caps Lock+Shift scenarios.

## Solution
Introduce a small keyboard-state override layer for ToUnicodeEx decoding that synchronizes Shift-down and Caps Lock toggle state from live key state, then cover the behavior with targeted tests in both the ring buffer and last-sequence conversion logic.

## Scope
Included: low-level decoding fix, Caps Lock/Shift regression tests, round-trip sequence tests for uppercase and shifted-lowercase paths.
Not included: broader input journal redesign or unrelated hotkey behavior changes.

## Validation
- cargo +nightly fmt --check
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly build --features debug-tracing
- cargo +nightly test --locked
- ctionlint -color
- zizmor --min-severity medium .

## Risks
The fix still depends on Windows reporting GetKeyState(VK_CAPITAL) consistently in the LL-hook timing window; that was not manually revalidated in a live GUI session in this run.