### PR TITLE
Serialize hotkey conversions and stabilize sequence handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ The config file is stored at:
 
 Default hotkey sequences:
 
-* Convert smart: double tap Left Shift
-* Autoconvert toggle: Left Shift + Right Shift
+* Convert last word: double tap Left Shift
+* Convert last sequence: double tap Left Alt
+* Convert selection: double tap Left Shift
+* Autoconvert toggle: double tap Right Ctrl
 * Switch layout: CapsLock
 
 ## Development

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -74,21 +74,20 @@ Notes:
 - Hotkey sequences are validated on save.
 
 Default bindings (current defaults in code):
-- Convert smart: double tap Left Shift within 1000 ms
-- Autoconvert toggle: press Left Shift + Right Shift together
+- Convert last word: double tap Left Shift within 1000 ms
+- Convert last sequence: double tap Left Alt within 1000 ms
+- Convert selection: double tap Left Shift within 1000 ms
+- Autoconvert toggle: double tap Right Ctrl within 1000 ms
 - Switch keyboard layout: CapsLock
-- Convert selection: configured but by default it is the same double tap Left Shift.
-  Since sequence matching checks Convert smart earlier, Convert selection is effectively shadowed unless rebound to a different sequence.
 
 ## Actions and behavior
 
-### Convert smart
-
-This is the primary conversion action.
+### Convert last word
 
 Behavior:
-- If there is a non empty selection, it converts the selection.
-- Otherwise it converts last sequence using the input journal.
+- Converts the last token captured by the input journal.
+- Sleeps for autoconvert_delay_ms before replacement.
+- Replaces only the final run, preserving trailing suffix text.
 
 ### Convert selection
 
@@ -142,9 +141,10 @@ Native Win32 UI with a single window and two group sections (custom painted fram
 
 ### Hotkeys group
 - Read only displays for:
-  - Convert smart (sequence)
+  - Convert last word
+  - Convert last sequence
   - Convert selection (sequence)
-  - Autoconvert toggle (sequence)
+  - Autoconvert pause
   - Switch layout (sequence)
 
 Buttons:
@@ -203,5 +203,4 @@ How it is gated:
 
 ## Known issues (current behavior)
 
-- Convert selection default sequence duplicates Convert smart and is shadowed unless user rebinds it.
 - Autostart depends on a shortcut pointing to the current exe path, so relocating the exe breaks autostart.

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,13 @@ use windows::Win32::{
     UI::WindowsAndMessaging::HMENU,
 };
 
-use crate::config;
+use crate::{config, input::hotkeys::HotkeyAction};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RuntimeCommand {
+    Hotkey(HotkeyAction),
+    AutoconvertLastWord,
+}
 
 #[derive(Debug, Clone)]
 pub struct UiError {
@@ -25,6 +31,7 @@ pub struct UiError {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum HotkeySlot {
     LastWord,
+    LastSequence,
     Pause,
     Selection,
     SwitchLayout,
@@ -33,6 +40,7 @@ pub enum HotkeySlot {
 #[derive(Debug, Default, Clone)]
 pub struct HotkeyValues {
     pub last_word: Option<config::Hotkey>,
+    pub last_sequence: Option<config::Hotkey>,
     pub pause: Option<config::Hotkey>,
     pub selection: Option<config::Hotkey>,
     pub switch_layout: Option<config::Hotkey>,
@@ -42,6 +50,7 @@ impl HotkeyValues {
     pub fn from_config(cfg: &config::Config) -> Self {
         Self {
             last_word: cfg.hotkey_convert_last_word,
+            last_sequence: cfg.hotkey_convert_last_sequence,
             pause: cfg.hotkey_pause,
             selection: cfg.hotkey_convert_selection,
             switch_layout: cfg.hotkey_switch_layout,
@@ -52,6 +61,7 @@ impl HotkeyValues {
     pub fn get(&self, slot: HotkeySlot) -> Option<config::Hotkey> {
         match slot {
             HotkeySlot::LastWord => self.last_word,
+            HotkeySlot::LastSequence => self.last_sequence,
             HotkeySlot::Pause => self.pause,
             HotkeySlot::Selection => self.selection,
             HotkeySlot::SwitchLayout => self.switch_layout,
@@ -61,6 +71,7 @@ impl HotkeyValues {
     pub fn set(&mut self, slot: HotkeySlot, hk: Option<config::Hotkey>) {
         match slot {
             HotkeySlot::LastWord => self.last_word = hk,
+            HotkeySlot::LastSequence => self.last_sequence = hk,
             HotkeySlot::Pause => self.pause = hk,
             HotkeySlot::Selection => self.selection = hk,
             HotkeySlot::SwitchLayout => self.switch_layout = hk,
@@ -71,6 +82,7 @@ impl HotkeyValues {
 #[derive(Debug, Default, Clone)]
 pub struct HotkeySequenceValues {
     pub last_word: Option<config::HotkeySequence>,
+    pub last_sequence: Option<config::HotkeySequence>,
     pub pause: Option<config::HotkeySequence>,
     pub selection: Option<config::HotkeySequence>,
     pub switch_layout: Option<config::HotkeySequence>,
@@ -80,6 +92,7 @@ impl HotkeySequenceValues {
     pub fn from_config(cfg: &config::Config) -> Self {
         Self {
             last_word: cfg.hotkey_convert_last_word_sequence,
+            last_sequence: cfg.hotkey_convert_last_sequence_sequence,
             pause: cfg.hotkey_pause_sequence,
             selection: cfg.hotkey_convert_selection_sequence,
             switch_layout: cfg.hotkey_switch_layout_sequence,
@@ -89,6 +102,7 @@ impl HotkeySequenceValues {
     pub fn get(&self, slot: HotkeySlot) -> Option<config::HotkeySequence> {
         match slot {
             HotkeySlot::LastWord => self.last_word,
+            HotkeySlot::LastSequence => self.last_sequence,
             HotkeySlot::Pause => self.pause,
             HotkeySlot::Selection => self.selection,
             HotkeySlot::SwitchLayout => self.switch_layout,
@@ -98,6 +112,7 @@ impl HotkeySequenceValues {
     pub fn set(&mut self, slot: HotkeySlot, seq: Option<config::HotkeySequence>) {
         match slot {
             HotkeySlot::LastWord => self.last_word = seq,
+            HotkeySlot::LastSequence => self.last_sequence = seq,
             HotkeySlot::Pause => self.pause = seq,
             HotkeySlot::Selection => self.selection = seq,
             HotkeySlot::SwitchLayout => self.switch_layout = seq,
@@ -120,6 +135,28 @@ pub struct HotkeyCaptureUi {
     pub last_input_tick_ms: u64,
 }
 
+impl HotkeyCaptureUi {
+    pub fn start(&mut self, slot: HotkeySlot) {
+        self.active = true;
+        self.slot = Some(slot);
+        self.pending_mods_vks = 0;
+        self.pending_mods = 0;
+        self.pending_mods_valid = false;
+        self.saw_non_mod = false;
+        self.last_input_tick_ms = 0;
+    }
+
+    pub fn stop(&mut self) {
+        self.active = false;
+        self.slot = None;
+        self.pending_mods_vks = 0;
+        self.pending_mods = 0;
+        self.pending_mods_valid = false;
+        self.saw_non_mod = false;
+        self.last_input_tick_ms = 0;
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct RuntimeChordCapture {
     pub pending_mods_vks: u32,
@@ -137,6 +174,7 @@ pub struct SequenceProgress {
 #[derive(Debug, Default)]
 pub struct HotkeySequenceProgress {
     pub last_word: SequenceProgress,
+    pub last_sequence: SequenceProgress,
     pub pause: SequenceProgress,
     pub selection: SequenceProgress,
     pub switch_layout: SequenceProgress,
@@ -175,6 +213,10 @@ pub struct AppState {
     /// Runtime state for chord sequence progress.
     pub hotkey_sequence_progress: HotkeySequenceProgress,
 
+    /// Serialized runtime commands triggered by hotkeys/autoconvert.
+    pub pending_runtime_commands: VecDeque<RuntimeCommand>,
+    pub runtime_command_running: bool,
+
     pub active_switch_layout_sequence: Option<config::HotkeySequence>,
     pub switch_layout_waiting_second: bool,
     pub switch_layout_first_tick_ms: u64,
@@ -201,6 +243,7 @@ pub struct Edits {
 #[derive(Debug, Default)]
 pub struct HotkeyEdits {
     pub last_word: HWND,
+    pub last_sequence: HWND,
     pub pause: HWND,
     pub selection: HWND,
     pub switch_layout: HWND,
@@ -224,9 +267,10 @@ pub enum ControlId {
     DarkTheme = 1005,
 
     HotkeyLastWord = 1201,
-    HotkeyPause = 1202,
-    HotkeySelection = 1203,
-    HotkeySwitchLayout = 1204,
+    HotkeyLastSequence = 1202,
+    HotkeyPause = 1203,
+    HotkeySelection = 1204,
+    HotkeySwitchLayout = 1205,
 
     Apply = 1101,
     Cancel = 1102,
@@ -244,9 +288,10 @@ impl ControlId {
             1005 => Some(Self::DarkTheme),
 
             1201 => Some(Self::HotkeyLastWord),
-            1202 => Some(Self::HotkeyPause),
-            1203 => Some(Self::HotkeySelection),
-            1204 => Some(Self::HotkeySwitchLayout),
+            1202 => Some(Self::HotkeyLastSequence),
+            1203 => Some(Self::HotkeyPause),
+            1204 => Some(Self::HotkeySelection),
+            1205 => Some(Self::HotkeySwitchLayout),
 
             1101 => Some(Self::Apply),
             1102 => Some(Self::Cancel),

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+use windows::Win32::UI::Input::KeyboardAndMouse::{MOD_ALT, MOD_CONTROL, MOD_SHIFT};
 
 const APP_DIR: &str = "RustSwitcher";
 const CONFIG_FILE: &str = "config.json";
@@ -52,18 +53,42 @@ pub struct Config {
     pub theme_dark: bool,
 
     pub hotkey_convert_last_word: Option<Hotkey>,
+    #[serde(default)]
+    pub hotkey_convert_last_sequence: Option<Hotkey>,
     pub hotkey_convert_selection: Option<Hotkey>,
     pub hotkey_switch_layout: Option<Hotkey>,
     pub hotkey_pause: Option<Hotkey>,
 
     #[serde(default)]
     pub hotkey_convert_last_word_sequence: Option<HotkeySequence>,
+    #[serde(default = "default_hotkey_convert_last_sequence_sequence")]
+    pub hotkey_convert_last_sequence_sequence: Option<HotkeySequence>,
     #[serde(default)]
     pub hotkey_pause_sequence: Option<HotkeySequence>,
     #[serde(default)]
     pub hotkey_convert_selection_sequence: Option<HotkeySequence>,
     #[serde(default)]
     pub hotkey_switch_layout_sequence: Option<HotkeySequence>,
+}
+
+fn modifier_only_chord(mods: u32, mods_vks: u32) -> HotkeyChord {
+    HotkeyChord {
+        mods,
+        mods_vks,
+        vk: None,
+    }
+}
+
+fn double_modifier_sequence(mods: u32, mods_vks: u32) -> HotkeySequence {
+    HotkeySequence {
+        first: modifier_only_chord(mods, mods_vks),
+        second: Some(modifier_only_chord(mods, mods_vks)),
+        max_gap_ms: 1000,
+    }
+}
+
+fn default_hotkey_convert_last_sequence_sequence() -> Option<HotkeySequence> {
+    Some(double_modifier_sequence(MOD_ALT.0, MODVK_LALT))
 }
 impl Default for Config {
     fn default() -> Self {
@@ -75,46 +100,20 @@ impl Default for Config {
             hotkey_switch_layout: None,
             hotkey_pause: None,
             hotkey_convert_last_word: None,
+            hotkey_convert_last_sequence: None,
             hotkey_convert_selection: None,
 
-            hotkey_convert_last_word_sequence: Some(HotkeySequence {
-                first: HotkeyChord {
-                    mods: 4,
-                    mods_vks: 4,
-                    vk: None,
-                },
-                second: Some(HotkeyChord {
-                    mods: 4,
-                    mods_vks: 4,
-                    vk: None,
-                }),
-                max_gap_ms: 1000,
-            }),
+            hotkey_convert_last_word_sequence: Some(double_modifier_sequence(
+                MOD_SHIFT.0,
+                MODVK_LSHIFT,
+            )),
+            hotkey_convert_last_sequence_sequence: default_hotkey_convert_last_sequence_sequence(),
 
-            hotkey_pause_sequence: Some(HotkeySequence {
-                first: HotkeyChord {
-                    mods: 4,
-                    mods_vks: 12,
-                    vk: None,
-                },
-                second: None,
-                max_gap_ms: 1000,
-            }),
-
-            hotkey_convert_selection_sequence: Some(HotkeySequence {
-                first: HotkeyChord {
-                    mods: 4,
-                    mods_vks: 4,
-                    vk: None,
-                },
-                second: Some(HotkeyChord {
-                    mods: 4,
-                    mods_vks: 4,
-                    vk: None,
-                }),
-                max_gap_ms: 1000,
-            }),
-
+            hotkey_pause_sequence: Some(double_modifier_sequence(MOD_CONTROL.0, MODVK_RCTRL)),
+            hotkey_convert_selection_sequence: Some(double_modifier_sequence(
+                MOD_SHIFT.0,
+                MODVK_LSHIFT,
+            )),
             hotkey_switch_layout_sequence: Some(HotkeySequence {
                 first: HotkeyChord {
                     mods: 0,

--- a/src/config/config_validator.rs
+++ b/src/config/config_validator.rs
@@ -2,21 +2,26 @@ use std::fmt::Write as _;
 
 use crate::config::{
     Config,
-    constants::{CONVERT_LAST_WORD, CONVERT_SELECTION, PAUSE, SWITCH_LAYOUT},
+    constants::{
+        CONVERT_LAST_SEQUENCE, CONVERT_LAST_WORD, CONVERT_SELECTION, PAUSE, SWITCH_LAYOUT,
+    },
 };
 
 pub fn find_duplicate_hotkey_sequences(config: &Config) -> Option<String> {
     let sequences = [
         (CONVERT_LAST_WORD, &config.hotkey_convert_last_word_sequence),
+        (
+            CONVERT_LAST_SEQUENCE,
+            &config.hotkey_convert_last_sequence_sequence,
+        ),
         (PAUSE, &config.hotkey_pause_sequence),
         (CONVERT_SELECTION, &config.hotkey_convert_selection_sequence),
         (SWITCH_LAYOUT, &config.hotkey_switch_layout_sequence),
     ];
 
-    // Allowed duplicates (bidirectional check)
     let is_allowed_duplicate = |a: &str, b: &str| {
-        (a == CONVERT_SELECTION && b == CONVERT_LAST_WORD)
-            || (a == CONVERT_LAST_WORD && b == CONVERT_SELECTION)
+        (a == CONVERT_LAST_WORD && b == CONVERT_SELECTION)
+            || (a == CONVERT_SELECTION && b == CONVERT_LAST_WORD)
     };
 
     let duplicates: Vec<_> = sequences

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -1,4 +1,5 @@
-pub const CONVERT_LAST_WORD: &str = "Convert last sequence";
+pub const CONVERT_LAST_WORD: &str = "Convert last word";
+pub const CONVERT_LAST_SEQUENCE: &str = "Convert last sequence";
 pub const CONVERT_SELECTION: &str = "Convert selection";
 pub const PAUSE: &str = "Autoconvert pause";
 pub const SWITCH_LAYOUT: &str = "Switch keyboard layout";

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -1,6 +1,6 @@
 pub mod input;
 
 pub use crate::domain::text::{
-    convert::{convert_selection, convert_selection_if_any},
-    last_word::convert_last_sequence,
+    convert::convert_selection,
+    last_word::{convert_last_sequence, convert_last_word},
 };

--- a/src/domain/text/convert.rs
+++ b/src/domain/text/convert.rs
@@ -69,6 +69,7 @@ fn probe_convertible_selection(max_chars: usize) -> Option<String> {
 ///
 /// Returns `true` if a non empty eligible selection was found (conversion attempted),
 /// otherwise `false`.
+#[allow(dead_code)]
 #[tracing::instrument(level = "trace", skip(state))]
 pub fn convert_selection_if_any(state: &mut AppState) -> bool {
     match convert_selection_outcome(state, MAX_SELECTION_CHARS) {

--- a/src/domain/text/last_word.rs
+++ b/src/domain/text/last_word.rs
@@ -39,15 +39,27 @@ fn convert_with_layout_fallback(text: &str, layout: &LayoutTag) -> String {
     .unwrap_or(ConversionDirection::RuToEn);
     convert_ru_en_with_direction(text, direction)
 }
+
+fn convert_sequence_runs(runs: &[InputRun]) -> String {
+    let mut out = String::new();
+
+    for run in runs {
+        match run.kind {
+            RunKind::Text => out.push_str(&convert_with_layout_fallback(&run.text, &run.layout)),
+            RunKind::Whitespace => out.push_str(&run.text),
+        }
+    }
+
+    out
+}
+pub fn convert_last_word(state: &mut AppState) {
+    convert_last_word_impl(state, true);
+}
+
 pub fn convert_last_sequence(state: &mut AppState) {
     convert_last_sequence_impl(state, true);
 }
 
-/// Backwards-compatible alias.
-#[allow(dead_code)]
-pub fn convert_last_word(state: &mut AppState) {
-    convert_last_sequence(state);
-}
 pub fn autoconvert_last_word(state: &mut AppState) {
     if !foreground_window_alive() {
         tracing::warn!("foreground window is null");
@@ -437,6 +449,43 @@ fn apply_last_word_replacement(p: &LastRunPayload, converted: &str) -> Result<()
         Err(ApplyError::KeyInjectionFailed)
     }
 }
+
+#[tracing::instrument(level = "trace", skip(state))]
+fn convert_last_word_impl(state: &mut AppState, switch_layout: bool) {
+    if !foreground_window_alive() {
+        tracing::warn!("foreground window is null");
+        return;
+    }
+    if switch_layout && !wait_shift_released(150) {
+        tracing::info!("wait_shift_released returned false");
+        return;
+    }
+    sleep_before_convert(state);
+    let Some(payload) = take_last_word_payload() else {
+        tracing::info!("journal: no last word");
+        return;
+    };
+    let mut restore = JournalRestore::new(&payload);
+    if payload.suffix_has_newline {
+        tracing::trace!("newline present, skipping convert_last_word");
+        return;
+    }
+    let converted = convert_with_layout_fallback(&payload.run.text, &payload.run.layout);
+    tracing::trace!(%converted, "converted");
+    if apply_last_word_conversion(&payload, &converted) {
+        update_journal(&payload, &converted);
+        restore.commit();
+        if switch_layout {
+            match switch_keyboard_layout() {
+                Ok(()) => tracing::trace!("layout switched"),
+                Err(e) => tracing::warn!(error = ?e, "layout switch failed"),
+            }
+        }
+    } else {
+        tracing::warn!("convert apply failed");
+    }
+}
+
 #[tracing::instrument(level = "trace", skip(state))]
 fn convert_last_sequence_impl(state: &mut AppState, switch_layout: bool) {
     if !foreground_window_alive() {
@@ -457,7 +506,7 @@ fn convert_last_sequence_impl(state: &mut AppState, switch_layout: bool) {
         tracing::trace!("newline present, skipping convert_last_sequence");
         return;
     }
-    let converted = convert_with_layout_fallback(&payload.seq_text, &payload.layout);
+    let converted = convert_sequence_runs(&payload.runs);
     tracing::trace!(%converted, "converted");
     if apply_last_sequence_conversion(&payload, &converted) {
         update_journal_sequence(&payload, &converted);
@@ -495,9 +544,11 @@ struct LastRunPayload {
 struct LastSequencePayload {
     prefix_runs: Vec<InputRun>,
     runs: Vec<InputRun>,
+    #[cfg_attr(not(test), allow(dead_code))]
     layout: LayoutTag,
     suffix_runs: Vec<InputRun>,
     suffix_text: String,
+    #[cfg_attr(not(test), allow(dead_code))]
     seq_text: String,
     seq_len: usize,
     suffix_len: usize,
@@ -545,55 +596,10 @@ fn join_runs_text(runs: &[InputRun]) -> String {
     runs.iter().map(|run| run.text.as_str()).collect()
 }
 
-fn split_sequence_runs_for_conversion(
-    runs: Vec<InputRun>,
-    detector: &lingua::LanguageDetector,
-) -> (Vec<InputRun>, Vec<InputRun>) {
-    let Some(last_idx) = runs.iter().rposition(|run| run.kind == RunKind::Text) else {
-        return (Vec::new(), runs);
-    };
-
-    if runs[last_idx].origin == RunOrigin::Programmatic {
-        return (Vec::new(), runs);
-    }
-
-    let layout = runs[last_idx].layout;
-    let mut selected_start = last_idx;
-
-    for idx in (0..last_idx).rev() {
-        let run = &runs[idx];
-        if run.kind != RunKind::Text {
-            continue;
-        }
-        if should_include_previous_sequence_run(run, layout, detector) {
-            selected_start = idx;
-            continue;
-        }
-        break;
-    }
-
-    let mut runs = runs;
-    let selected_runs = runs.split_off(selected_start);
-    (runs, selected_runs)
-}
-
-fn should_include_previous_sequence_run(
-    run: &InputRun,
-    layout: LayoutTag,
-    detector: &lingua::LanguageDetector,
-) -> bool {
-    if !matches!(layout, LayoutTag::En | LayoutTag::Ru) {
-        return false;
-    }
-
-    let converted = convert_with_layout_fallback(&run.text, &layout);
-    should_autoconvert_word(detector, &run.text, &converted).is_ok()
-}
-
 fn take_last_sequence_payload() -> Option<LastSequencePayload> {
-    let (raw_runs, suffix_runs) = crate::input_journal::take_last_layout_sequence_with_suffix()?;
-    let detector = language_detector();
-    let (prefix_runs, runs) = split_sequence_runs_for_conversion(raw_runs, detector);
+    let (runs, suffix_runs) =
+        crate::input_journal::take_last_programmatic_sequence_with_suffix()
+            .or_else(crate::input_journal::take_last_layout_sequence_with_suffix)?;
     let last = runs.last()?;
     if last.kind != RunKind::Text {
         return None;
@@ -621,7 +627,7 @@ fn take_last_sequence_payload() -> Option<LastSequencePayload> {
     );
 
     Some(LastSequencePayload {
-        prefix_runs,
+        prefix_runs: Vec::new(),
         runs,
         layout,
         suffix_runs,
@@ -697,13 +703,27 @@ fn restore_journal_original_sequence(p: &LastSequencePayload) {
 
 fn update_journal_sequence(p: &LastSequencePayload, converted: &str) {
     crate::input_journal::push_runs(p.prefix_runs.iter().cloned());
-    crate::input_journal::push_text_with_meta(
-        converted,
-        flipped_layout(p.layout),
-        RunOrigin::Programmatic,
-    );
+    crate::input_journal::push_runs(p.runs.iter().map(|run| {
+        let text = match run.kind {
+            RunKind::Whitespace => run.text.clone(),
+            RunKind::Text => convert_with_layout_fallback(&run.text, &run.layout),
+        };
+
+        let layout = if run.kind == RunKind::Text && text != run.text {
+            flipped_layout(run.layout)
+        } else {
+            run.layout
+        };
+
+        InputRun {
+            text,
+            layout,
+            origin: RunOrigin::Programmatic,
+            kind: run.kind,
+        }
+    }));
     crate::input_journal::push_runs(p.suffix_runs.iter().cloned());
-    tracing::trace!("journal updated (sequence)");
+    tracing::trace!(%converted, "journal updated (sequence)");
 }
 fn restore_journal_original(p: &LastRunPayload) {
     crate::input_journal::push_run(p.run.clone());
@@ -881,6 +901,83 @@ mod tests {
         assert_eq!(converted, "приветб");
         assert!(should_autoconvert_word(&detector, word, &converted).is_ok());
     }
+
+    #[test]
+    fn last_word_payload_extracts_only_final_text_run() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "rjynhjkm".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: "  ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+        ]);
+
+        let payload = take_last_word_payload().expect("payload expected");
+        assert_eq!(payload.run.text, "rjynhjkm");
+        assert_eq!(payload.suffix_text, "  ");
+        assert_eq!(payload.run.layout, LayoutTag::En);
+    }
+
+    #[test]
+    fn update_journal_for_last_word_keeps_prefix_runs() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "rjynhjkm".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let payload = take_last_word_payload().expect("payload expected");
+        update_journal(&payload, "школа");
+
+        let runs = ring_buffer::runs_snapshot();
+        assert_eq!(runs.len(), 3);
+        assert_eq!(runs[0].text, "ghbdtn");
+        assert_eq!(runs[0].layout, LayoutTag::En);
+        assert_eq!(runs[1].text, " ");
+        assert_eq!(runs[1].kind, RunKind::Whitespace);
+        assert_eq!(runs[2].text, "школа");
+        assert_eq!(runs[2].layout, LayoutTag::Ru);
+        assert_eq!(runs[2].origin, RunOrigin::Programmatic);
+    }
+
     #[test]
     fn last_sequence_payload_spans_whitespace_and_uses_single_layout() {
         let _guard = test_lock();
@@ -953,13 +1050,14 @@ mod tests {
         assert_eq!(p1.seq_text, "ghbdtn rjynhjkm");
 
         // Simulate manual conversion journal update (programmatic RU)
-        update_journal_sequence(&p1, "привет школа");
+        let c1 = convert_sequence_runs(&p1.runs);
+        update_journal_sequence(&p1, &c1);
 
         // Second extraction must succeed (programmatic RU), enabling toggle-back.
         let p2 = take_last_sequence_payload()
             .expect("sequence payload after programmatic update expected");
         assert_eq!(p2.layout, LayoutTag::Ru);
-        assert_eq!(p2.seq_text, "привет школа");
+        assert_eq!(p2.seq_text, "привет контроль");
         assert!(p2.suffix_text.is_empty());
         assert!(p2.prefix_runs.is_empty());
     }
@@ -990,17 +1088,42 @@ mod tests {
         ]);
 
         let p1 = take_last_sequence_payload().expect("first sequence payload expected");
-        let c1 = convert_with_layout_fallback(&p1.seq_text, &p1.layout);
+        let c1 = convert_sequence_runs(&p1.runs);
         assert_ne!(c1, p1.seq_text);
         update_journal_sequence(&p1, &c1);
 
         let p2 = take_last_sequence_payload().expect("second sequence payload expected");
-        let c2 = convert_with_layout_fallback(&p2.seq_text, &p2.layout);
+        let c2 = convert_sequence_runs(&p2.runs);
         update_journal_sequence(&p2, &c2);
 
         let p3 = take_last_sequence_payload().expect("third sequence payload expected");
         assert_eq!(p3.layout, LayoutTag::En);
         assert_eq!(p3.seq_text, p1.seq_text);
+    }
+
+    #[test]
+    fn last_sequence_payload_stops_on_layout_change_without_whitespace() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: "руддщ".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        assert!(payload.prefix_runs.is_empty());
+        assert_eq!(payload.seq_text, "руддщ");
+        assert_eq!(payload.layout, LayoutTag::Ru);
     }
 
     #[test]
@@ -1062,6 +1185,48 @@ mod tests {
     }
 
     #[test]
+    fn manual_sequence_preserves_suffix_after_programmatic_roundtrip() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "rjynhjkm".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: "  ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+        ]);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        assert_eq!(payload.suffix_text, "  ");
+        let converted = convert_sequence_runs(&payload.runs);
+        update_journal_sequence(&payload, &converted);
+
+        let next = take_last_sequence_payload().expect("sequence payload after update expected");
+        assert_eq!(next.layout, LayoutTag::Ru);
+        assert_eq!(next.seq_text, "привет контроль");
+        assert_eq!(next.suffix_text, "  ");
+    }
+
+    #[test]
     fn update_journal_sequence_preserves_whitespace_tokenization() {
         let _guard = test_lock();
         ring_buffer::invalidate();
@@ -1087,10 +1252,11 @@ mod tests {
         ]);
 
         let payload = take_last_sequence_payload().expect("sequence payload expected");
-        update_journal_sequence(&payload, "привет школа");
+        let converted = convert_sequence_runs(&payload.runs);
+        update_journal_sequence(&payload, &converted);
 
         let (runs, suffix) =
-            ring_buffer::take_last_layout_sequence_with_suffix().expect("seq expected");
+            ring_buffer::take_last_programmatic_sequence_with_suffix().expect("seq expected");
         assert!(suffix.is_empty());
         assert_eq!(runs.len(), 3);
         assert_eq!(runs[0].text, "привет");
@@ -1099,12 +1265,12 @@ mod tests {
         assert_eq!(runs[0].layout, LayoutTag::Ru);
         assert_eq!(runs[1].text, " ");
         assert_eq!(runs[1].kind, RunKind::Whitespace);
-        assert_eq!(runs[2].text, "школа");
+        assert_eq!(runs[2].text, "контроль");
         assert_eq!(runs[2].kind, RunKind::Text);
     }
 
     #[test]
-    fn last_sequence_payload_stops_before_previous_correct_english_word() {
+    fn last_sequence_payload_includes_previous_english_word_in_same_sequence() {
         let _guard = test_lock();
         ring_buffer::invalidate();
         ring_buffer::push_runs([
@@ -1129,15 +1295,13 @@ mod tests {
         ]);
 
         let payload = take_last_sequence_payload().expect("sequence payload expected");
-        assert_eq!(payload.prefix_runs.len(), 2);
-        assert_eq!(payload.prefix_runs[0].text, "hello");
-        assert_eq!(payload.prefix_runs[1].text, " ");
-        assert_eq!(payload.seq_text, "ghbdtn");
+        assert!(payload.prefix_runs.is_empty());
+        assert_eq!(payload.seq_text, "hello ghbdtn");
         assert_eq!(payload.layout, LayoutTag::En);
     }
 
     #[test]
-    fn last_sequence_payload_stops_before_previous_correct_russian_word() {
+    fn last_sequence_payload_includes_previous_russian_word_in_same_sequence() {
         let _guard = test_lock();
         ring_buffer::invalidate();
         ring_buffer::push_runs([
@@ -1162,15 +1326,13 @@ mod tests {
         ]);
 
         let payload = take_last_sequence_payload().expect("sequence payload expected");
-        assert_eq!(payload.prefix_runs.len(), 2);
-        assert_eq!(payload.prefix_runs[0].text, "привет");
-        assert_eq!(payload.prefix_runs[1].text, " ");
-        assert_eq!(payload.seq_text, "руддщ");
+        assert!(payload.prefix_runs.is_empty());
+        assert_eq!(payload.seq_text, "привет руддщ");
         assert_eq!(payload.layout, LayoutTag::Ru);
     }
 
     #[test]
-    fn update_journal_sequence_keeps_unconverted_prefix_runs() {
+    fn update_journal_sequence_converts_full_same_layout_sequence() {
         let _guard = test_lock();
         ring_buffer::invalidate();
         ring_buffer::push_runs([
@@ -1195,17 +1357,240 @@ mod tests {
         ]);
 
         let payload = take_last_sequence_payload().expect("sequence payload expected");
-        update_journal_sequence(&payload, "привет");
+        update_journal_sequence(&payload, "руддщ привет");
 
         let runs = ring_buffer::runs_snapshot();
         assert_eq!(runs.len(), 3);
-        assert_eq!(runs[0].text, "hello");
-        assert_eq!(runs[0].layout, LayoutTag::En);
+        assert_eq!(runs[0].text, "руддщ");
+        assert_eq!(runs[0].layout, LayoutTag::Ru);
+        assert_eq!(runs[0].origin, RunOrigin::Programmatic);
         assert_eq!(runs[1].text, " ");
         assert_eq!(runs[1].kind, RunKind::Whitespace);
         assert_eq!(runs[2].text, "привет");
         assert_eq!(runs[2].layout, LayoutTag::Ru);
         assert_eq!(runs[2].origin, RunOrigin::Programmatic);
+    }
+
+    #[test]
+    fn last_sequence_payload_keeps_multiple_words_in_single_layout_sequence() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "руддщ".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "вапр".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "dfgdfgh".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        assert_eq!(payload.layout, LayoutTag::Ru);
+        assert_eq!(payload.seq_text, "руддщ вапр dfgdfgh");
+        assert!(payload.prefix_runs.is_empty());
+    }
+
+    #[test]
+    fn mixed_script_sequence_roundtrip_current_behavior_is_explicit() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_run(InputRun {
+            text: "fdghdrfghdfgh dfgh dfgh dfgh вапвапр".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        });
+
+        let p1 = take_last_sequence_payload().expect("first sequence payload expected");
+        assert_eq!(p1.seq_text, "fdghdrfghdfgh dfgh dfgh dfgh вапвапр");
+        assert_eq!(p1.layout, LayoutTag::En);
+        let c1 = convert_with_layout_fallback(&p1.seq_text, &p1.layout);
+        assert_eq!(c1, "авпрвкапрвапр вапр вапр вапр вапвапр");
+        update_journal_sequence(&p1, &c1);
+
+        let p2 = take_last_sequence_payload().expect("second sequence payload expected");
+        assert_eq!(p2.seq_text, "авпрвкапрвапр вапр вапр вапр вапвапр");
+        assert_eq!(p2.layout, LayoutTag::Ru);
+        let c2 = convert_with_layout_fallback(&p2.seq_text, &p2.layout);
+        assert_eq!(c2, "fdghdrfghdfgh dfgh dfgh dfgh dfgdfgh");
+    }
+
+    #[test]
+    fn last_word_after_sequence_update_targets_only_final_programmatic_word() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "rjynhjkm".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let seq = take_last_sequence_payload().expect("sequence payload expected");
+        let converted = convert_sequence_runs(&seq.runs);
+        update_journal_sequence(&seq, &converted);
+
+        let word = take_last_word_payload().expect("word payload expected");
+        assert_eq!(word.run.text, "контроль");
+        assert_eq!(word.run.layout, LayoutTag::Ru);
+        assert_eq!(word.run.origin, RunOrigin::Programmatic);
+    }
+
+    #[test]
+    fn last_sequence_after_last_word_update_targets_only_last_programmatic_word() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "rjynhjkm".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let word = take_last_word_payload().expect("word payload expected");
+        let converted = convert_with_layout_fallback(&word.run.text, &word.run.layout);
+        update_journal(&word, &converted);
+
+        let seq = take_last_sequence_payload().expect("sequence payload expected");
+        assert_eq!(seq.seq_text, "контроль");
+        assert_eq!(seq.layout, LayoutTag::Ru);
+        assert!(seq.prefix_runs.is_empty());
+    }
+
+    #[test]
+    fn new_physical_tail_after_sequence_update_does_not_read_back_into_previous_sequence() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "rjynhjkm".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let seq = take_last_sequence_payload().expect("sequence payload expected");
+        let converted = convert_sequence_runs(&seq.runs);
+        update_journal_sequence(&seq, &converted);
+
+        ring_buffer::push_run(InputRun {
+            text: "asdf".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        });
+
+        let tail = take_last_sequence_payload().expect("tail payload expected");
+        assert_eq!(tail.seq_text, "asdf");
+        assert_eq!(tail.layout, LayoutTag::En);
+        assert!(tail.prefix_runs.is_empty());
+    }
+
+    #[test]
+    fn exact_phrase_hfp_ldf_nhb_converts_as_full_last_sequence() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "hfp".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "ldf".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "nhb".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        assert_eq!(payload.seq_text, "hfp ldf nhb");
+        assert_eq!(convert_sequence_runs(&payload.runs), "раз два три");
     }
 
     #[test]

--- a/src/input/hotkeys.rs
+++ b/src/input/hotkeys.rs
@@ -11,6 +11,7 @@ use crate::config;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HotkeyAction {
     ConvertLastWord,
+    ConvertLastSequence,
     PauseToggle,
     ConvertSelection,
     SwitchLayout,
@@ -20,13 +21,15 @@ pub enum HotkeyAction {
 const HK_ID_BASE: i32 = 20000;
 
 pub const HK_CONVERT_LAST_WORD_ID: i32 = HK_ID_BASE + 1;
-pub const HK_PAUSE_TOGGLE_ID: i32 = HK_ID_BASE + 2;
-pub const HK_CONVERT_SELECTION_ID: i32 = HK_ID_BASE + 3;
-pub const HK_SWITCH_LAYOUT_ID: i32 = HK_ID_BASE + 4;
+pub const HK_CONVERT_LAST_SEQUENCE_ID: i32 = HK_ID_BASE + 2;
+pub const HK_PAUSE_TOGGLE_ID: i32 = HK_ID_BASE + 3;
+pub const HK_CONVERT_SELECTION_ID: i32 = HK_ID_BASE + 4;
+pub const HK_SWITCH_LAYOUT_ID: i32 = HK_ID_BASE + 5;
 
 pub fn action_from_id(id: i32) -> Option<HotkeyAction> {
     match id {
         HK_CONVERT_LAST_WORD_ID => Some(HotkeyAction::ConvertLastWord),
+        HK_CONVERT_LAST_SEQUENCE_ID => Some(HotkeyAction::ConvertLastSequence),
         HK_PAUSE_TOGGLE_ID => Some(HotkeyAction::PauseToggle),
         HK_CONVERT_SELECTION_ID => Some(HotkeyAction::ConvertSelection),
         HK_SWITCH_LAYOUT_ID => Some(HotkeyAction::SwitchLayout),
@@ -46,6 +49,7 @@ fn unregister_one_quiet(hwnd: HWND, id: i32) -> windows::core::Result<()> {
 pub fn unregister_all(hwnd: HWND) -> windows::core::Result<()> {
     for id in [
         HK_CONVERT_LAST_WORD_ID,
+        HK_CONVERT_LAST_SEQUENCE_ID,
         HK_PAUSE_TOGGLE_ID,
         HK_CONVERT_SELECTION_ID,
         HK_SWITCH_LAYOUT_ID,
@@ -92,6 +96,11 @@ pub fn register_from_config(hwnd: HWND, cfg: &config::Config) -> windows::core::
     unregister_all(hwnd)?;
 
     register_one(hwnd, HK_CONVERT_LAST_WORD_ID, cfg.hotkey_convert_last_word)?;
+    register_one(
+        hwnd,
+        HK_CONVERT_LAST_SEQUENCE_ID,
+        cfg.hotkey_convert_last_sequence,
+    )?;
     register_one(hwnd, HK_PAUSE_TOGGLE_ID, cfg.hotkey_pause)?;
     register_one(hwnd, HK_CONVERT_SELECTION_ID, cfg.hotkey_convert_selection)?;
     register_one(hwnd, HK_SWITCH_LAYOUT_ID, cfg.hotkey_switch_layout)?;

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -320,6 +320,40 @@ impl InputJournal {
         Some((seq_rev, suffix_runs))
     }
 
+    fn take_last_programmatic_sequence_with_suffix(
+        &mut self,
+    ) -> Option<(Vec<InputRun>, Vec<InputRun>)> {
+        let mut suffix_runs = self.pop_suffix_whitespace();
+
+        if self
+            .runs
+            .back()
+            .is_none_or(|run| run.origin != RunOrigin::Programmatic)
+        {
+            self.restore_suffix(&mut suffix_runs);
+            return None;
+        }
+
+        let mut seq_rev: Vec<InputRun> = Vec::new();
+        while let Some(run) = self.runs.back() {
+            if run.origin != RunOrigin::Programmatic {
+                break;
+            }
+            let run = self.runs.pop_back()?;
+            self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
+            seq_rev.push(run);
+        }
+
+        if seq_rev.is_empty() {
+            self.restore_suffix(&mut suffix_runs);
+            return None;
+        }
+
+        seq_rev.reverse();
+        suffix_runs.reverse();
+        Some((seq_rev, suffix_runs))
+    }
+
     fn pop_suffix_whitespace(&mut self) -> Vec<InputRun> {
         let mut suffix_runs: Vec<InputRun> = Vec::new();
         while self
@@ -408,6 +442,16 @@ fn mods_ctrl_or_alt_down() -> bool {
     let ctrl = unsafe { GetAsyncKeyState(0x11) }.cast_unsigned();
     let alt = unsafe { GetAsyncKeyState(0x12) }.cast_unsigned();
     (ctrl & 0x8000) != 0 || (alt & 0x8000) != 0
+}
+
+#[cfg(windows)]
+fn is_modifier_vk(vk: VIRTUAL_KEY) -> bool {
+    matches!(vk.0, 0xA0..=0xA5 | 0x5B | 0x5C)
+}
+
+#[cfg(windows)]
+fn should_clear_for_ctrl_alt_combo(vk: VIRTUAL_KEY, ctrl_or_alt_down: bool) -> bool {
+    ctrl_or_alt_down && !is_modifier_vk(vk)
 }
 
 #[cfg(windows)]
@@ -559,7 +603,7 @@ pub fn record_keydown(kb: &KBDLLHOOKSTRUCT, vk: u32) -> Option<String> {
         _ => {}
     }
 
-    if mods_ctrl_or_alt_down() {
+    if should_clear_for_ctrl_alt_combo(vk, mods_ctrl_or_alt_down()) {
         action = Some(JournalAction::Clear);
     }
 
@@ -606,6 +650,11 @@ pub fn take_last_layout_sequence_with_suffix() -> Option<(Vec<InputRun>, Vec<Inp
     with_journal_mut(|j| j.take_last_layout_sequence_with_suffix())
 }
 
+#[must_use]
+pub fn take_last_programmatic_sequence_with_suffix() -> Option<(Vec<InputRun>, Vec<InputRun>)> {
+    with_journal_mut(|j| j.take_last_programmatic_sequence_with_suffix())
+}
+
 #[cfg(test)]
 pub fn push_text(s: &str) {
     with_journal_mut(|j| j.push_text_internal(s, LayoutTag::Unknown, RunOrigin::Programmatic));
@@ -617,11 +666,6 @@ pub fn push_run(run: InputRun) {
 
 pub fn push_runs(runs: impl IntoIterator<Item = InputRun>) {
     with_journal_mut(|j| j.push_runs(runs));
-}
-
-#[cfg(any(test, windows))]
-pub fn push_text_with_meta(text: &str, layout: LayoutTag, origin: RunOrigin) {
-    with_journal_mut(|j| j.push_text_internal(text, layout, origin));
 }
 
 #[cfg(test)]
@@ -666,6 +710,27 @@ pub fn last_char_triggers_autoconvert() -> bool {
 #[cfg(all(test, windows))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ctrl_or_alt_combo_preserves_modifier_only_layout_switch_chords() {
+        assert!(!should_clear_for_ctrl_alt_combo(VK_LSHIFT, true));
+        assert!(!should_clear_for_ctrl_alt_combo(VK_RSHIFT, true));
+        assert!(!should_clear_for_ctrl_alt_combo(VIRTUAL_KEY(0xA4), true));
+        assert!(!should_clear_for_ctrl_alt_combo(VIRTUAL_KEY(0xA5), true));
+    }
+
+    #[test]
+    fn ctrl_or_alt_combo_still_clears_non_modifier_keys() {
+        assert!(should_clear_for_ctrl_alt_combo(
+            VIRTUAL_KEY(u16::from(b'A')),
+            true
+        ));
+        assert!(should_clear_for_ctrl_alt_combo(VK_TAB, true));
+        assert!(!should_clear_for_ctrl_alt_combo(
+            VIRTUAL_KEY(u16::from(b'A')),
+            false
+        ));
+    }
 
     #[test]
     fn keyboard_state_overrides_apply_caps_lock_toggle_without_touching_high_bit() {

--- a/src/input_journal.rs
+++ b/src/input_journal.rs
@@ -1,4 +1,5 @@
 pub use crate::input::ring_buffer::{
     InputRun, LayoutTag, RunKind, RunOrigin, mark_last_token_autoconverted, push_run, push_runs,
-    push_text_with_meta, take_last_layout_run_with_suffix, take_last_layout_sequence_with_suffix,
+    take_last_layout_run_with_suffix, take_last_layout_sequence_with_suffix,
+    take_last_programmatic_sequence_with_suffix,
 };

--- a/src/platform/ui.rs
+++ b/src/platform/ui.rs
@@ -324,19 +324,19 @@ fn create_hotkey_rows(
         hy,
         g.w_label,
         g.w_edit,
-        w!("Convert last sequence:"),
+        w!("Convert last word:"),
         Some(ControlId::HotkeyLastWord.hmenu()),
     )?;
     hy += 28;
 
-    state.hotkeys.pause = create_hotkey_row(
+    state.hotkeys.last_sequence = create_hotkey_row(
         hwnd,
         g.hx,
         hy,
         g.w_label,
         g.w_edit,
-        w!("Autoconvert pause:"),
-        Some(ControlId::HotkeyPause.hmenu()),
+        w!("Convert last sequence:"),
+        Some(ControlId::HotkeyLastSequence.hmenu()),
     )?;
     hy += 28;
 
@@ -348,6 +348,17 @@ fn create_hotkey_rows(
         g.w_edit,
         w!("Convert selection:"),
         Some(ControlId::HotkeySelection.hmenu()),
+    )?;
+    hy += 28;
+
+    state.hotkeys.pause = create_hotkey_row(
+        hwnd,
+        g.hx,
+        hy,
+        g.w_label,
+        g.w_edit,
+        w!("Autoconvert pause:"),
+        Some(ControlId::HotkeyPause.hmenu()),
     )?;
     hy += 28;
 

--- a/src/platform/win.rs
+++ b/src/platform/win.rs
@@ -25,13 +25,18 @@ use windows::{
         Foundation::{HWND, LPARAM, LRESULT, WPARAM},
         Graphics::Gdi::{DeleteObject, HFONT, HGDIOBJ, UpdateWindow},
         System::LibraryLoader::GetModuleHandleW,
-        UI::WindowsAndMessaging::{
-            DefWindowProcW, FindWindowW, GWLP_USERDATA, GetWindowLongPtrW, IsWindowVisible,
-            PostMessageW, PostQuitMessage, RegisterWindowMessageW, SC_CLOSE, SC_MINIMIZE,
-            SIZE_MINIMIZED, SW_HIDE, SW_RESTORE, SW_SHOW, SW_SHOWNORMAL, SetForegroundWindow,
-            SetWindowLongPtrW, ShowWindow, WM_APP, WM_CLOSE, WM_COMMAND, WM_CREATE, WM_CTLCOLORBTN,
-            WM_CTLCOLORDLG, WM_CTLCOLORSTATIC, WM_DESTROY, WM_DRAWITEM, WM_HOTKEY, WM_PAINT,
-            WM_SIZE, WM_SYSCOMMAND, WM_TIMER, WS_MAXIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_THICKFRAME,
+        UI::{
+            Input::KeyboardAndMouse::SetFocus,
+            WindowsAndMessaging::{
+                DefWindowProcW, FindWindowW, GWLP_USERDATA, GetWindowLongPtrW, IsWindow,
+                IsWindowVisible, PostMessageW, PostQuitMessage, RegisterWindowMessageW, SC_CLOSE,
+                SC_MINIMIZE, SIZE_MINIMIZED, SW_HIDE, SW_RESTORE, SW_SHOW, SW_SHOWNORMAL,
+                SetForegroundWindow, SetWindowLongPtrW, ShowWindow, WM_APP, WM_CLOSE, WM_COMMAND,
+                WM_CREATE, WM_CTLCOLORBTN, WM_CTLCOLORDLG, WM_CTLCOLORSTATIC, WM_DESTROY,
+                WM_DRAWITEM, WM_HOTKEY, WM_LBUTTONDOWN, WM_MBUTTONDOWN, WM_PAINT, WM_PARENTNOTIFY,
+                WM_RBUTTONDOWN, WM_SIZE, WM_SYSCOMMAND, WM_TIMER, WS_MAXIMIZEBOX,
+                WS_OVERLAPPEDWINDOW, WS_THICKFRAME,
+            },
         },
     },
     core::{PCWSTR, Result, w},
@@ -48,7 +53,7 @@ pub(crate) const AUTOSTART_ARG: &str = "--autostart";
 use windows::Win32::UI::WindowsAndMessaging::{WM_CTLCOLOREDIT, WM_ERASEBKGND};
 
 use crate::{
-    app::AppState,
+    app::{AppState, RuntimeCommand},
     config,
     domain::text::{last_word::autoconvert_last_word, switch_keyboard_layout},
     input::hotkeys::{HotkeyAction, action_from_id},
@@ -69,6 +74,7 @@ use crate::{
 };
 
 const WM_APP_APPLY_THEME: u32 = WM_APP + 1;
+const WM_APP_RUN_RUNTIME_COMMAND: u32 = WM_APP + 2;
 
 #[rustfmt::skip]
 #[cfg(debug_assertions)]
@@ -134,6 +140,30 @@ fn refresh_tray_tooltip(hwnd: HWND, state: &AppState) {
     }
 }
 
+fn hotkey_capture_focus_fallback(hwnd: HWND, state: &AppState) -> HWND {
+    if !state.buttons.apply.0.is_null() {
+        state.buttons.apply
+    } else {
+        hwnd
+    }
+}
+
+pub(crate) fn stop_hotkey_capture_ui(hwnd: HWND, state: &mut AppState) {
+    let was_active = state.hotkey_capture.active;
+    state.hotkey_capture.stop();
+
+    if was_active && !hwnd.0.is_null() {
+        let target = hotkey_capture_focus_fallback(hwnd, state);
+        unsafe {
+            if IsWindow(Some(target)).as_bool() {
+                let _ = SetFocus(Some(target));
+            } else if IsWindow(Some(hwnd)).as_bool() {
+                let _ = SetFocus(Some(hwnd));
+            }
+        }
+    }
+}
+
 pub fn refresh_autostart_checkbox(state: &mut AppState) -> windows::core::Result<()> {
     let enabled = crate::platform::win::autostart::is_enabled()?;
     crate::utils::helpers::set_checkbox(state.checkboxes.autostart, enabled);
@@ -156,6 +186,13 @@ fn apply_config_to_ui(state: &mut AppState, cfg: &config::Config) -> windows::co
         format_hotkey(cfg.hotkey_convert_last_word)
     };
     set_hwnd_text(state.hotkeys.last_word, &last_word_text)?;
+
+    let last_sequence_text = if cfg.hotkey_convert_last_sequence_sequence.is_some() {
+        format_hotkey_sequence(cfg.hotkey_convert_last_sequence_sequence)
+    } else {
+        format_hotkey(cfg.hotkey_convert_last_sequence)
+    };
+    set_hwnd_text(state.hotkeys.last_sequence, &last_sequence_text)?;
 
     let pause_text = if cfg.hotkey_pause_sequence.is_some() {
         format_hotkey_sequence(cfg.hotkey_pause_sequence)
@@ -188,6 +225,7 @@ fn read_ui_to_config(state: &AppState, mut cfg: config::Config) -> config::Confi
     cfg.theme_dark = helpers::get_checkbox(state.checkboxes.theme_dark);
 
     cfg.hotkey_convert_last_word_sequence = state.hotkey_sequence_values.last_word;
+    cfg.hotkey_convert_last_sequence_sequence = state.hotkey_sequence_values.last_sequence;
     cfg.hotkey_pause_sequence = state.hotkey_sequence_values.pause;
     cfg.hotkey_convert_selection_sequence = state.hotkey_sequence_values.selection;
     cfg.hotkey_switch_layout_sequence = state.hotkey_sequence_values.switch_layout;
@@ -205,6 +243,10 @@ fn read_ui_to_config(state: &AppState, mut cfg: config::Config) -> config::Confi
     cfg.hotkey_convert_last_word = hk_or_none_if_double(
         cfg.hotkey_convert_last_word_sequence,
         state.hotkey_values.last_word,
+    );
+    cfg.hotkey_convert_last_sequence = hk_or_none_if_double(
+        cfg.hotkey_convert_last_sequence_sequence,
+        state.hotkey_values.last_sequence,
     );
     cfg.hotkey_pause = hk_or_none_if_double(cfg.hotkey_pause_sequence, state.hotkey_values.pause);
     cfg.hotkey_convert_selection = hk_or_none_if_double(
@@ -453,6 +495,14 @@ pub extern "system" fn wndproc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPA
         WM_HOTKEY => on_hotkey(hwnd, wparam),
         WM_TIMER => on_timer(hwnd, wparam, lparam),
         WM_PAINT => crate::platform::ui::themes::on_paint(hwnd, wparam, lparam),
+        WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN => {
+            with_state_mut_do(hwnd, |state| stop_hotkey_capture_ui(hwnd, state));
+            unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
+        }
+        WM_PARENTNOTIFY => {
+            with_state_mut_do(hwnd, |state| stop_hotkey_capture_ui(hwnd, state));
+            unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
+        }
 
         //Purpose: Customize the background color of a dialog box itself.
         //When sent: When the dialog box background is about to be painted.
@@ -524,11 +574,16 @@ pub extern "system" fn wndproc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPA
             }
 
             with_state_mut_do(hwnd, |state| {
-                if state.autoconvert_enabled {
-                    autoconvert_last_word(state);
-                }
+                enqueue_runtime_command(hwnd, state, RuntimeCommand::AutoconvertLastWord);
             });
 
+            LRESULT(0)
+        }
+
+        WM_APP_RUN_RUNTIME_COMMAND => {
+            with_state_mut_do(hwnd, |state| {
+                process_next_runtime_command(hwnd, state);
+            });
             LRESULT(0)
         }
 
@@ -713,11 +768,74 @@ fn handle_pause_toggle(hwnd: HWND, state: &mut AppState) {
     set_autoconvert_enabled_from_tray(hwnd, state, enabled, true);
 }
 
-fn handle_convert_smart(state: &mut AppState) {
-    if crate::conversion::convert_selection_if_any(state) {
+fn last_word_hotkey_should_try_selection_first(state: &AppState) -> bool {
+    let last_word = state.active_hotkey_sequences.last_word;
+    let selection = state.active_hotkey_sequences.selection;
+    last_word.is_some() && last_word == selection
+}
+
+fn handle_convert_last_word_hotkey(state: &mut AppState) {
+    if last_word_hotkey_should_try_selection_first(state)
+        && crate::domain::text::convert::convert_selection_if_any(state)
+    {
         return;
     }
-    crate::conversion::convert_last_sequence(state);
+
+    crate::conversion::convert_last_word(state);
+}
+
+fn execute_runtime_command(hwnd: HWND, state: &mut AppState, command: RuntimeCommand) {
+    match command {
+        RuntimeCommand::AutoconvertLastWord => {
+            if state.autoconvert_enabled {
+                autoconvert_last_word(state);
+            }
+        }
+        RuntimeCommand::Hotkey(action) => match action {
+            HotkeyAction::PauseToggle => {
+                tracing::warn!(msg = "autoconvert_toggle", source = "hotkey_pause_toggle");
+                handle_pause_toggle(hwnd, state);
+            }
+            HotkeyAction::ConvertLastWord => handle_convert_last_word_hotkey(state),
+            HotkeyAction::ConvertLastSequence => crate::conversion::convert_last_sequence(state),
+            HotkeyAction::ConvertSelection => crate::conversion::convert_selection(state),
+            HotkeyAction::SwitchLayout => {
+                let _ = switch_keyboard_layout();
+            }
+        },
+    }
+}
+
+fn enqueue_runtime_command(hwnd: HWND, state: &mut AppState, command: RuntimeCommand) {
+    state.pending_runtime_commands.push_back(command);
+
+    if state.runtime_command_running || state.pending_runtime_commands.len() != 1 {
+        return;
+    }
+
+    unsafe {
+        let _ = PostMessageW(Some(hwnd), WM_APP_RUN_RUNTIME_COMMAND, WPARAM(0), LPARAM(0));
+    }
+}
+
+fn process_next_runtime_command(hwnd: HWND, state: &mut AppState) {
+    if state.runtime_command_running {
+        return;
+    }
+
+    let Some(command) = state.pending_runtime_commands.pop_front() else {
+        return;
+    };
+
+    state.runtime_command_running = true;
+    execute_runtime_command(hwnd, state, command);
+    state.runtime_command_running = false;
+
+    if !state.pending_runtime_commands.is_empty() {
+        unsafe {
+            let _ = PostMessageW(Some(hwnd), WM_APP_RUN_RUNTIME_COMMAND, WPARAM(0), LPARAM(0));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -742,16 +860,8 @@ fn on_hotkey(hwnd: HWND, wparam: WPARAM) -> LRESULT {
         return LRESULT(0);
     };
 
-    with_state_mut(hwnd, |state| match action {
-        HotkeyAction::PauseToggle => {
-            tracing::warn!(msg = "autoconvert_toggle", source = "hotkey_pause_toggle");
-            handle_pause_toggle(hwnd, state)
-        }
-        HotkeyAction::ConvertLastWord => handle_convert_smart(state),
-        HotkeyAction::ConvertSelection => crate::conversion::convert_selection(state),
-        HotkeyAction::SwitchLayout => {
-            let _ = switch_keyboard_layout();
-        }
+    with_state_mut(hwnd, |state| {
+        enqueue_runtime_command(hwnd, state, RuntimeCommand::Hotkey(action));
     });
 
     LRESULT(0)
@@ -818,5 +928,146 @@ fn set_autoconvert_enabled_from_tray(
 
     if let Err(e) = crate::platform::win::tray::balloon_info(hwnd, "Rust Switcher", &body) {
         tracing::warn!(error = ?e, "tray balloon failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr;
+
+    use super::*;
+    use crate::{app::HotkeySequenceValues, config};
+
+    fn seq(vk: u32) -> config::HotkeySequence {
+        config::HotkeySequence {
+            first: config::HotkeyChord {
+                mods: 0,
+                mods_vks: 0,
+                vk: Some(vk),
+            },
+            second: None,
+            max_gap_ms: 250,
+        }
+    }
+
+    #[test]
+    fn last_word_hotkey_tries_selection_first_when_sequences_match() {
+        let state = AppState {
+            active_hotkey_sequences: HotkeySequenceValues {
+                last_word: Some(seq(u32::from(b'A'))),
+                selection: Some(seq(u32::from(b'A'))),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(last_word_hotkey_should_try_selection_first(&state));
+    }
+
+    #[test]
+    fn last_word_hotkey_does_not_try_selection_when_sequences_differ() {
+        let state = AppState {
+            active_hotkey_sequences: HotkeySequenceValues {
+                last_word: Some(seq(u32::from(b'A'))),
+                selection: Some(seq(u32::from(b'B'))),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(!last_word_hotkey_should_try_selection_first(&state));
+    }
+
+    #[test]
+    fn stop_hotkey_capture_clears_active_capture_state() {
+        let mut state = AppState::default();
+        state
+            .hotkey_capture
+            .start(crate::app::HotkeySlot::LastSequence);
+        assert!(state.hotkey_capture.active);
+
+        stop_hotkey_capture_ui(HWND::default(), &mut state);
+
+        assert!(!state.hotkey_capture.active);
+        assert_eq!(state.hotkey_capture.slot, None);
+        assert_eq!(state.hotkey_capture.pending_mods, 0);
+        assert_eq!(state.hotkey_capture.pending_mods_vks, 0);
+    }
+
+    #[test]
+    fn hotkey_capture_focus_fallback_prefers_apply_button() {
+        let mut state = AppState::default();
+        state.buttons.apply = HWND(ptr::dangling_mut());
+
+        let target = hotkey_capture_focus_fallback(HWND(ptr::dangling_mut()), &state);
+        assert_eq!(target, state.buttons.apply);
+    }
+
+    #[test]
+    fn hotkey_capture_focus_fallback_uses_window_when_apply_missing() {
+        let state = AppState::default();
+        let hwnd = HWND(ptr::dangling_mut());
+
+        let target = hotkey_capture_focus_fallback(hwnd, &state);
+        assert_eq!(target, hwnd);
+    }
+
+    #[test]
+    fn enqueue_runtime_command_records_fifo_series() {
+        let mut state = AppState::default();
+
+        enqueue_runtime_command(
+            HWND::default(),
+            &mut state,
+            RuntimeCommand::Hotkey(HotkeyAction::ConvertLastSequence),
+        );
+        enqueue_runtime_command(
+            HWND::default(),
+            &mut state,
+            RuntimeCommand::AutoconvertLastWord,
+        );
+        enqueue_runtime_command(
+            HWND::default(),
+            &mut state,
+            RuntimeCommand::Hotkey(HotkeyAction::ConvertLastWord),
+        );
+
+        assert_eq!(
+            state
+                .pending_runtime_commands
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![
+                RuntimeCommand::Hotkey(HotkeyAction::ConvertLastSequence),
+                RuntimeCommand::AutoconvertLastWord,
+                RuntimeCommand::Hotkey(HotkeyAction::ConvertLastWord),
+            ]
+        );
+        assert!(!state.runtime_command_running);
+    }
+
+    #[test]
+    fn enqueue_runtime_command_keeps_items_queued_while_running() {
+        let mut state = AppState {
+            runtime_command_running: true,
+            ..Default::default()
+        };
+
+        enqueue_runtime_command(
+            HWND::default(),
+            &mut state,
+            RuntimeCommand::Hotkey(HotkeyAction::SwitchLayout),
+        );
+
+        assert_eq!(
+            state
+                .pending_runtime_commands
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![RuntimeCommand::Hotkey(HotkeyAction::SwitchLayout)]
+        );
+        assert!(state.runtime_command_running);
     }
 }

--- a/src/platform/win/commands.rs
+++ b/src/platform/win/commands.rs
@@ -30,6 +30,7 @@ fn handle_hotkey_capture_focus(hwnd: HWND, id: i32, notif: u32) -> Option<LRESUL
 
     let slot = match cid {
         ControlId::HotkeyLastWord => crate::app::HotkeySlot::LastWord,
+        ControlId::HotkeyLastSequence => crate::app::HotkeySlot::LastSequence,
         ControlId::HotkeyPause => crate::app::HotkeySlot::Pause,
         ControlId::HotkeySelection => crate::app::HotkeySlot::Selection,
         ControlId::HotkeySwitchLayout => crate::app::HotkeySlot::SwitchLayout,
@@ -39,13 +40,7 @@ fn handle_hotkey_capture_focus(hwnd: HWND, id: i32, notif: u32) -> Option<LRESUL
     match notif {
         EN_SETFOCUS => {
             with_state_mut_do(hwnd, |state| {
-                state.hotkey_capture.active = true;
-                state.hotkey_capture.slot = Some(slot);
-                state.hotkey_capture.pending_mods_vks = 0;
-                state.hotkey_capture.pending_mods = 0;
-                state.hotkey_capture.pending_mods_valid = false;
-                state.hotkey_capture.saw_non_mod = false;
-                state.hotkey_capture.last_input_tick_ms = 0;
+                state.hotkey_capture.start(slot);
 
                 #[cfg(debug_assertions)]
                 tracing::debug!(slot = ?slot, "hotkey.capture.start");
@@ -55,7 +50,7 @@ fn handle_hotkey_capture_focus(hwnd: HWND, id: i32, notif: u32) -> Option<LRESUL
 
         EN_KILLFOCUS => {
             with_state_mut_do(hwnd, |state| {
-                state.hotkey_capture.active = false;
+                super::stop_hotkey_capture_ui(hwnd, state);
 
                 #[cfg(debug_assertions)]
                 tracing::debug!(slot = ?slot, "hotkey.capture.stop");

--- a/src/platform/win/keyboard/capture.rs
+++ b/src/platform/win/keyboard/capture.rs
@@ -66,6 +66,7 @@ pub(crate) fn store_captured_hotkey(
 pub(crate) fn ui_hotkey_target(state: &crate::app::AppState, slot: crate::app::HotkeySlot) -> HWND {
     match slot {
         crate::app::HotkeySlot::LastWord => state.hotkeys.last_word,
+        crate::app::HotkeySlot::LastSequence => state.hotkeys.last_sequence,
         crate::app::HotkeySlot::Pause => state.hotkeys.pause,
         crate::app::HotkeySlot::Selection => state.hotkeys.selection,
         crate::app::HotkeySlot::SwitchLayout => state.hotkeys.switch_layout,

--- a/src/platform/win/keyboard/keydown.rs
+++ b/src/platform/win/keyboard/keydown.rs
@@ -40,18 +40,25 @@ pub(crate) fn handle_keydown_in_state(
     let chord = chord_from_vk(vk);
 
     if state.hotkey_capture.active {
-        return handle_keydown_capture(state, chord, is_mod, now_ms);
+        return handle_keydown_capture(hwnd, state, vk, chord, is_mod, now_ms);
     }
 
     handle_keydown_runtime(hwnd, state, chord, is_mod, now_ms)
 }
 
 pub(crate) fn handle_keydown_capture(
+    hwnd: HWND,
     state: &mut crate::app::AppState,
+    vk: u32,
     chord: config::HotkeyChord,
     is_mod: bool,
     now_ms: u64,
 ) -> windows::core::Result<HookDecision> {
+    if matches!(vk, 0x0D | 0x1B) {
+        crate::platform::win::stop_hotkey_capture_ui(hwnd, state);
+        return Ok(HookDecision::Swallow);
+    }
+
     let Some(slot) = state.hotkey_capture.slot else {
         return Ok(HookDecision::Pass);
     };
@@ -103,4 +110,46 @@ pub(crate) fn handle_keydown_runtime(
     } else {
         HookDecision::Pass
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{app::HotkeySlot, config};
+
+    fn chord() -> config::HotkeyChord {
+        config::HotkeyChord {
+            mods: 0,
+            mods_vks: 0,
+            vk: Some(u32::from(b'A')),
+        }
+    }
+
+    #[test]
+    fn enter_stops_hotkey_capture() {
+        let mut state = crate::app::AppState::default();
+        state.hotkey_capture.start(HotkeySlot::LastWord);
+
+        let decision =
+            handle_keydown_capture(HWND::default(), &mut state, 0x0D, chord(), false, 100)
+                .expect("capture should succeed");
+
+        assert_eq!(decision, HookDecision::Swallow);
+        assert!(!state.hotkey_capture.active);
+        assert_eq!(state.hotkey_capture.slot, None);
+    }
+
+    #[test]
+    fn escape_stops_hotkey_capture() {
+        let mut state = crate::app::AppState::default();
+        state.hotkey_capture.start(HotkeySlot::LastSequence);
+
+        let decision =
+            handle_keydown_capture(HWND::default(), &mut state, 0x1B, chord(), false, 100)
+                .expect("capture should succeed");
+
+        assert_eq!(decision, HookDecision::Swallow);
+        assert!(!state.hotkey_capture.active);
+        assert_eq!(state.hotkey_capture.slot, None);
+    }
 }

--- a/src/platform/win/keyboard/keyup.rs
+++ b/src/platform/win/keyboard/keyup.rs
@@ -128,3 +128,89 @@ pub(crate) fn handle_keyup_runtime(
         HookDecision::Pass
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use windows::Win32::UI::Input::KeyboardAndMouse::MOD_ALT;
+
+    use super::*;
+    use crate::{
+        app::{AppState, HotkeySequenceValues},
+        config::{HotkeyChord, HotkeySequence, MODVK_LALT},
+        platform::win::keyboard::{
+            keydown::handle_keydown_in_state,
+            mods::{reset_mods_state, update_mods_down_press, update_mods_down_release},
+        },
+    };
+
+    const VK_LALT: u32 = 0xA4;
+
+    fn double_left_alt_sequence() -> HotkeySequence {
+        let chord = HotkeyChord {
+            mods: MOD_ALT.0,
+            mods_vks: MODVK_LALT,
+            vk: None,
+        };
+
+        HotkeySequence {
+            first: chord,
+            second: Some(chord),
+            max_gap_ms: 1000,
+        }
+    }
+
+    #[test]
+    fn modifier_only_last_sequence_advances_on_first_left_alt_release() {
+        reset_mods_state();
+
+        let mut state = AppState {
+            active_hotkey_sequences: HotkeySequenceValues {
+                last_sequence: Some(double_left_alt_sequence()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        update_mods_down_press(VK_LALT);
+        let down = handle_keydown_in_state(HWND::default(), &mut state, VK_LALT, true, 100)
+            .expect("keydown should succeed");
+        update_mods_down_release(VK_LALT);
+        let up = handle_keyup_in_state(HWND::default(), &mut state, VK_LALT, true, 150)
+            .expect("keyup should succeed");
+
+        assert_eq!(down, HookDecision::Pass);
+        assert_eq!(up, HookDecision::Swallow);
+        assert!(state.hotkey_sequence_progress.last_sequence.waiting_second);
+
+        reset_mods_state();
+    }
+
+    #[test]
+    fn modifier_only_last_sequence_triggers_on_second_left_alt_release() {
+        reset_mods_state();
+
+        let mut state = AppState {
+            active_hotkey_sequences: HotkeySequenceValues {
+                last_sequence: Some(double_left_alt_sequence()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        for (down_ms, up_ms) in [(100_u64, 150_u64), (250_u64, 300_u64)] {
+            update_mods_down_press(VK_LALT);
+            let down = handle_keydown_in_state(HWND::default(), &mut state, VK_LALT, true, down_ms)
+                .expect("keydown should succeed");
+            update_mods_down_release(VK_LALT);
+            let up = handle_keyup_in_state(HWND::default(), &mut state, VK_LALT, true, up_ms)
+                .expect("keyup should succeed");
+
+            assert_eq!(down, HookDecision::Pass);
+            assert_eq!(up, HookDecision::Swallow);
+        }
+
+        assert!(!state.hotkey_sequence_progress.last_sequence.waiting_second);
+
+        reset_mods_state();
+    }
+}

--- a/src/platform/win/keyboard/mods.rs
+++ b/src/platform/win/keyboard/mods.rs
@@ -45,3 +45,9 @@ pub(crate) fn chord_from_vk(vk: u32) -> config::HotkeyChord {
 pub(crate) fn mods_now() -> u32 {
     MODS_DOWN.load(Ordering::Relaxed)
 }
+
+#[cfg(test)]
+pub(crate) fn reset_mods_state() {
+    MODS_DOWN.store(0, Ordering::Relaxed);
+    MODVKS_DOWN.store(0, Ordering::Relaxed);
+}

--- a/src/platform/win/keyboard/sequence.rs
+++ b/src/platform/win/keyboard/sequence.rs
@@ -7,9 +7,17 @@ use crate::{
     app::HotkeySlot,
     config,
     input::hotkeys::{
-        HK_CONVERT_LAST_WORD_ID, HK_CONVERT_SELECTION_ID, HK_PAUSE_TOGGLE_ID, HK_SWITCH_LAYOUT_ID,
+        HK_CONVERT_LAST_SEQUENCE_ID, HK_CONVERT_LAST_WORD_ID, HK_CONVERT_SELECTION_ID,
+        HK_PAUSE_TOGGLE_ID, HK_SWITCH_LAYOUT_ID,
     },
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SequenceMatch {
+    NoMatch,
+    Consumed,
+    Triggered(HotkeySlot),
+}
 
 pub(crate) fn chord_matches(template: config::HotkeyChord, input: config::HotkeyChord) -> bool {
     if template.mods != input.mods {
@@ -30,6 +38,7 @@ pub(crate) fn progress_for_slot_mut(
 ) -> &mut crate::app::SequenceProgress {
     match slot {
         HotkeySlot::LastWord => &mut state.hotkey_sequence_progress.last_word,
+        HotkeySlot::LastSequence => &mut state.hotkey_sequence_progress.last_sequence,
         HotkeySlot::Pause => &mut state.hotkey_sequence_progress.pause,
         HotkeySlot::Selection => &mut state.hotkey_sequence_progress.selection,
         HotkeySlot::SwitchLayout => &mut state.hotkey_sequence_progress.switch_layout,
@@ -39,6 +48,7 @@ pub(crate) fn progress_for_slot_mut(
 pub(crate) fn hotkey_id_for_slot(slot: crate::app::HotkeySlot) -> i32 {
     match slot {
         HotkeySlot::LastWord => HK_CONVERT_LAST_WORD_ID,
+        HotkeySlot::LastSequence => HK_CONVERT_LAST_SEQUENCE_ID,
         HotkeySlot::Pause => HK_PAUSE_TOGGLE_ID,
         HotkeySlot::Selection => HK_CONVERT_SELECTION_ID,
         HotkeySlot::SwitchLayout => HK_SWITCH_LAYOUT_ID,
@@ -61,14 +71,13 @@ pub(crate) fn post_hotkey(hwnd: HWND, id: i32) -> windows::core::Result<()> {
 }
 
 pub(crate) fn try_match_sequence(
-    hwnd: HWND,
     state: &mut crate::app::AppState,
     slot: crate::app::HotkeySlot,
     chord: config::HotkeyChord,
     now_ms: u64,
-) -> windows::core::Result<bool> {
+) -> SequenceMatch {
     let Some(seq) = state.active_hotkey_sequences.get(slot) else {
-        return Ok(false);
+        return SequenceMatch::NoMatch;
     };
 
     let first = seq.first;
@@ -76,10 +85,9 @@ pub(crate) fn try_match_sequence(
     // Single chord
     let Some(second) = seq.second else {
         if chord_matches(first, chord) {
-            post_hotkey(hwnd, hotkey_id_for_slot(slot))?;
-            return Ok(true);
+            return SequenceMatch::Triggered(slot);
         }
-        return Ok(false);
+        return SequenceMatch::NoMatch;
     };
 
     let gap_ms = effective_gap_ms(slot, seq);
@@ -98,27 +106,47 @@ pub(crate) fn try_match_sequence(
             prog.waiting_second = false;
             prog.first_tick_ms = 0;
 
-            post_hotkey(hwnd, hotkey_id_for_slot(slot))?;
-            return Ok(true);
+            return SequenceMatch::Triggered(slot);
         }
 
         if chord_matches(first, chord) {
             prog.first_tick_ms = now_ms;
-            return Ok(true);
+            return SequenceMatch::Consumed;
         }
 
         prog.waiting_second = false;
         prog.first_tick_ms = 0;
-        return Ok(false);
+        return SequenceMatch::NoMatch;
     }
 
     if chord_matches(first, chord) {
         prog.waiting_second = true;
         prog.first_tick_ms = now_ms;
-        return Ok(true);
+        return SequenceMatch::Consumed;
     }
 
-    Ok(false)
+    SequenceMatch::NoMatch
+}
+
+pub(crate) fn try_match_any_sequence_slot(
+    state: &mut crate::app::AppState,
+    chord: config::HotkeyChord,
+    now_ms: u64,
+) -> SequenceMatch {
+    for slot in [
+        crate::app::HotkeySlot::SwitchLayout,
+        crate::app::HotkeySlot::LastWord,
+        crate::app::HotkeySlot::LastSequence,
+        crate::app::HotkeySlot::Selection,
+        crate::app::HotkeySlot::Pause,
+    ] {
+        let result = try_match_sequence(state, slot, chord, now_ms);
+        if result != SequenceMatch::NoMatch {
+            return result;
+        }
+    }
+
+    SequenceMatch::NoMatch
 }
 
 pub(crate) fn try_match_any_sequence(
@@ -127,15 +155,151 @@ pub(crate) fn try_match_any_sequence(
     chord: config::HotkeyChord,
     now_ms: u64,
 ) -> windows::core::Result<bool> {
-    for slot in [
-        crate::app::HotkeySlot::SwitchLayout,
-        crate::app::HotkeySlot::LastWord,
-        crate::app::HotkeySlot::Selection,
-        crate::app::HotkeySlot::Pause,
-    ] {
-        if try_match_sequence(hwnd, state, slot, chord, now_ms)? {
-            return Ok(true);
+    match try_match_any_sequence_slot(state, chord, now_ms) {
+        SequenceMatch::NoMatch => Ok(false),
+        SequenceMatch::Consumed => Ok(true),
+        SequenceMatch::Triggered(slot) => {
+            post_hotkey(hwnd, hotkey_id_for_slot(slot))?;
+            Ok(true)
         }
     }
-    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use windows::Win32::UI::Input::KeyboardAndMouse::{MOD_ALT, MOD_SHIFT};
+
+    use super::*;
+    use crate::{
+        app::{AppState, HotkeySequenceValues},
+        config::{HotkeyChord, HotkeySequence, MODVK_LALT, MODVK_LSHIFT},
+    };
+
+    fn modifier_only_chord(mods: u32, mods_vks: u32) -> HotkeyChord {
+        HotkeyChord {
+            mods,
+            mods_vks,
+            vk: None,
+        }
+    }
+
+    fn double_modifier_sequence(mods: u32, mods_vks: u32) -> HotkeySequence {
+        HotkeySequence {
+            first: modifier_only_chord(mods, mods_vks),
+            second: Some(modifier_only_chord(mods, mods_vks)),
+            max_gap_ms: 1000,
+        }
+    }
+
+    fn state_with_sequences(sequences: HotkeySequenceValues) -> AppState {
+        AppState {
+            active_hotkey_sequences: sequences,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn double_left_alt_triggers_last_sequence() {
+        let mut state = state_with_sequences(HotkeySequenceValues {
+            last_sequence: Some(double_modifier_sequence(MOD_ALT.0, MODVK_LALT)),
+            ..Default::default()
+        });
+        let chord = modifier_only_chord(MOD_ALT.0, MODVK_LALT);
+
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, chord, 100),
+            SequenceMatch::Consumed
+        );
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, chord, 250),
+            SequenceMatch::Triggered(HotkeySlot::LastSequence)
+        );
+    }
+
+    #[test]
+    fn double_left_alt_respects_gap_timeout() {
+        let mut state = state_with_sequences(HotkeySequenceValues {
+            last_sequence: Some(double_modifier_sequence(MOD_ALT.0, MODVK_LALT)),
+            ..Default::default()
+        });
+        let chord = modifier_only_chord(MOD_ALT.0, MODVK_LALT);
+
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, chord, 100),
+            SequenceMatch::Consumed
+        );
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, chord, 1201),
+            SequenceMatch::Consumed
+        );
+    }
+
+    #[test]
+    fn shared_double_left_shift_prioritizes_last_word_before_selection() {
+        let shared = double_modifier_sequence(MOD_SHIFT.0, MODVK_LSHIFT);
+        let mut state = state_with_sequences(HotkeySequenceValues {
+            last_word: Some(shared),
+            selection: Some(shared),
+            ..Default::default()
+        });
+        let chord = modifier_only_chord(MOD_SHIFT.0, MODVK_LSHIFT);
+
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, chord, 100),
+            SequenceMatch::Consumed
+        );
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, chord, 250),
+            SequenceMatch::Triggered(HotkeySlot::LastWord)
+        );
+    }
+
+    #[test]
+    fn single_chord_switch_layout_triggers_immediately() {
+        let chord = HotkeyChord {
+            mods: 0,
+            mods_vks: 0,
+            vk: Some(20),
+        };
+        let mut state = state_with_sequences(HotkeySequenceValues {
+            switch_layout: Some(HotkeySequence {
+                first: chord,
+                second: None,
+                max_gap_ms: 1000,
+            }),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, chord, 100),
+            SequenceMatch::Triggered(HotkeySlot::SwitchLayout)
+        );
+    }
+
+    #[test]
+    fn mismatched_second_chord_resets_sequence_and_allows_retry() {
+        let mut state = state_with_sequences(HotkeySequenceValues {
+            last_sequence: Some(double_modifier_sequence(MOD_ALT.0, MODVK_LALT)),
+            ..Default::default()
+        });
+        let left_alt = modifier_only_chord(MOD_ALT.0, MODVK_LALT);
+        let wrong = modifier_only_chord(MOD_SHIFT.0, MODVK_LSHIFT);
+
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, left_alt, 100),
+            SequenceMatch::Consumed
+        );
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, wrong, 200),
+            SequenceMatch::NoMatch
+        );
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, left_alt, 300),
+            SequenceMatch::Consumed
+        );
+        assert_eq!(
+            try_match_any_sequence_slot(&mut state, left_alt, 400),
+            SequenceMatch::Triggered(HotkeySlot::LastSequence)
+        );
+    }
 }

--- a/src/tests/config_io_tests.rs
+++ b/src/tests/config_io_tests.rs
@@ -4,10 +4,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use windows::Win32::UI::Input::KeyboardAndMouse::MOD_CONTROL;
+use windows::Win32::UI::Input::KeyboardAndMouse::{MOD_ALT, MOD_CONTROL, MOD_SHIFT};
 
 use super::env_lock::lock_env;
-use crate::config::{self, Config, HotkeyChord, HotkeySequence};
+use crate::config::{
+    self, Config, HotkeyChord, HotkeySequence, MODVK_LALT, MODVK_LSHIFT, MODVK_RCTRL,
+};
 
 fn unique_temp_dir(prefix: &str) -> PathBuf {
     let ts = SystemTime::now()
@@ -90,4 +92,67 @@ fn config_save_rejects_invalid_sequences() {
     let err = config::save(&cfg).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
     assert!(err.to_string().contains("unique hotkey sequence"));
+}
+
+#[test]
+fn default_hotkey_sequences_keep_last_word_on_double_left_shift() {
+    let cfg = Config::default();
+    let seq = cfg
+        .hotkey_convert_last_word_sequence
+        .expect("default last-word hotkey");
+
+    assert_eq!(seq.first.mods, MOD_SHIFT.0);
+    assert_eq!(seq.first.mods_vks, MODVK_LSHIFT);
+    assert_eq!(seq.first.vk, None);
+    assert_eq!(seq.second, Some(seq.first));
+}
+
+#[test]
+fn default_hotkey_sequences_use_double_left_alt_for_last_sequence() {
+    let cfg = Config::default();
+    let seq = cfg
+        .hotkey_convert_last_sequence_sequence
+        .expect("default last-sequence hotkey");
+
+    assert_eq!(seq.first.mods, MOD_ALT.0);
+    assert_eq!(seq.first.mods_vks, MODVK_LALT);
+    assert_eq!(seq.first.vk, None);
+    assert_eq!(seq.second, Some(seq.first));
+}
+
+#[test]
+fn default_hotkey_sequences_keep_switch_layout_on_capslock() {
+    let cfg = Config::default();
+    let seq = cfg
+        .hotkey_switch_layout_sequence
+        .expect("default switch-layout hotkey");
+
+    assert_eq!(seq.first.mods, 0);
+    assert_eq!(seq.first.mods_vks, 0);
+    assert_eq!(seq.first.vk, Some(20));
+    assert_eq!(seq.second, None);
+}
+
+#[test]
+fn default_hotkey_sequences_use_double_right_ctrl_for_pause() {
+    let cfg = Config::default();
+    let seq = cfg.hotkey_pause_sequence.expect("default pause hotkey");
+
+    assert_eq!(seq.first.mods, MOD_CONTROL.0);
+    assert_eq!(seq.first.mods_vks, MODVK_RCTRL);
+    assert_eq!(seq.first.vk, None);
+    assert_eq!(seq.second, Some(seq.first));
+}
+
+#[test]
+fn default_hotkey_sequences_keep_convert_selection_on_double_left_shift() {
+    let cfg = Config::default();
+    let seq = cfg
+        .hotkey_convert_selection_sequence
+        .expect("default selection hotkey");
+
+    assert_eq!(seq.first.mods, MOD_SHIFT.0);
+    assert_eq!(seq.first.mods_vks, MODVK_LSHIFT);
+    assert_eq!(seq.first.vk, None);
+    assert_eq!(seq.second, Some(seq.first));
 }

--- a/src/tests/config_validator_tests.rs
+++ b/src/tests/config_validator_tests.rs
@@ -2,7 +2,9 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{MOD_ALT, MOD_CONTROL, MOD_SHIF
 
 use crate::config::{
     Config, HotkeyChord, HotkeySequence,
-    constants::{CONVERT_LAST_WORD, CONVERT_SELECTION, PAUSE, SWITCH_LAYOUT},
+    constants::{
+        CONVERT_LAST_SEQUENCE, CONVERT_LAST_WORD, CONVERT_SELECTION, PAUSE, SWITCH_LAYOUT,
+    },
 };
 
 fn chord(mods: u32, mods_vks: u32, vk: u32) -> HotkeyChord {
@@ -47,12 +49,14 @@ fn seq2(mods1: u32, vk1: u32, mods2: u32, vk2: u32, max_gap_ms: u32) -> HotkeySe
 
 fn mk_cfg(
     last_word: Option<HotkeySequence>,
+    last_sequence: Option<HotkeySequence>,
     pause: Option<HotkeySequence>,
     selection: Option<HotkeySequence>,
     layout: Option<HotkeySequence>,
 ) -> Config {
     Config {
         hotkey_convert_last_word_sequence: last_word,
+        hotkey_convert_last_sequence_sequence: last_sequence,
         hotkey_pause_sequence: pause,
         hotkey_convert_selection_sequence: selection,
         hotkey_switch_layout_sequence: layout,
@@ -86,13 +90,14 @@ fn assert_has_common_error_shape(err: &str) {
 
 #[test]
 fn no_sequences_ok() {
-    assert_ok(mk_cfg(None, None, None, None));
+    assert_ok(mk_cfg(None, None, None, None, None));
 }
 
 #[test]
 fn only_one_sequence_ok() {
     assert_ok(mk_cfg(
         Some(seq1(MOD_CONTROL.0, u32::from(b'A'))),
+        None,
         None,
         None,
         None,
@@ -106,6 +111,7 @@ fn no_duplicates_ok() {
         Some(seq1(MOD_ALT.0, u32::from(b'B'))),
         Some(seq1(MOD_SHIFT.0, u32::from(b'C'))),
         Some(seq1(MOD_WIN.0, u32::from(b'D'))),
+        Some(seq1(MOD_CONTROL.0 | MOD_SHIFT.0, u32::from(b'E'))),
     ));
 }
 
@@ -115,9 +121,27 @@ fn allowed_duplicate_last_word_and_selection_ok() {
     assert_ok(mk_cfg(
         Some(same),
         Some(seq1(MOD_ALT.0, u32::from(b'B'))),
-        Some(seq1(MOD_CONTROL.0, u32::from(b'X'))),
         Some(seq1(MOD_SHIFT.0, u32::from(b'C'))),
+        Some(seq1(MOD_CONTROL.0, u32::from(b'X'))),
+        Some(seq1(MOD_WIN.0, u32::from(b'D'))),
     ));
+}
+
+#[test]
+fn duplicate_last_word_and_last_sequence_err() {
+    let dup = seq1(MOD_CONTROL.0, u32::from(b'A'));
+
+    let err = assert_err(mk_cfg(Some(dup), Some(dup), None, None, None));
+
+    assert_has_common_error_shape(&err);
+    assert!(err.contains(CONVERT_LAST_WORD), "{err}");
+    assert!(err.contains(CONVERT_LAST_SEQUENCE), "{err}");
+    assert!(
+        err.contains(&format!(
+            "• '{CONVERT_LAST_WORD}' and '{CONVERT_LAST_SEQUENCE}'\n"
+        )),
+        "{err}"
+    );
 }
 
 #[test]
@@ -126,6 +150,7 @@ fn duplicate_pause_and_layout_err() {
 
     let err = assert_err(mk_cfg(
         Some(seq1(MOD_CONTROL.0, u32::from(b'A'))),
+        Some(seq1(MOD_SHIFT.0, u32::from(b'X'))),
         Some(dup),
         Some(seq1(MOD_SHIFT.0, u32::from(b'C'))),
         Some(seq1(MOD_ALT.0, u32::from(b'B'))),
@@ -141,31 +166,12 @@ fn duplicate_pause_and_layout_err() {
 }
 
 #[test]
-fn duplicate_last_word_and_pause_err() {
-    let dup = seq1(MOD_CONTROL.0, u32::from(b'A'));
-
-    let err = assert_err(mk_cfg(
-        Some(dup),
-        Some(seq1(MOD_CONTROL.0, u32::from(b'A'))),
-        Some(seq1(MOD_SHIFT.0, u32::from(b'C'))),
-        Some(seq1(MOD_ALT.0, u32::from(b'B'))),
-    ));
-
-    assert_has_common_error_shape(&err);
-    assert!(err.contains(CONVERT_LAST_WORD), "{err}");
-    assert!(err.contains(PAUSE), "{err}");
-    assert!(
-        err.contains(&format!("• '{CONVERT_LAST_WORD}' and '{PAUSE}'\n")),
-        "{err}"
-    );
-}
-
-#[test]
 fn duplicate_selection_and_pause_err() {
     let dup = seq1(MOD_CONTROL.0, u32::from(b'A'));
 
     let err = assert_err(mk_cfg(
-        Some(seq1(MOD_SHIFT.0, u32::from(b'C'))),
+        Some(seq1(MOD_SHIFT.0, u32::from(b'W'))),
+        Some(seq1(MOD_SHIFT.0, u32::from(b'X'))),
         Some(dup),
         Some(seq1(MOD_CONTROL.0, u32::from(b'A'))),
         Some(seq1(MOD_ALT.0, u32::from(b'B'))),
@@ -181,29 +187,6 @@ fn duplicate_selection_and_pause_err() {
 }
 
 #[test]
-fn allowed_duplicate_pair_but_third_action_same_still_err_lists_two_pairs() {
-    let same = seq1(MOD_CONTROL.0, u32::from(b'X'));
-
-    let err = assert_err(mk_cfg(
-        Some(same),
-        Some(seq1(MOD_CONTROL.0, u32::from(b'X'))),
-        Some(seq1(MOD_CONTROL.0, u32::from(b'X'))),
-        None,
-    ));
-
-    assert_has_common_error_shape(&err);
-
-    let expected_1 = format!("• '{CONVERT_LAST_WORD}' and '{PAUSE}'\n");
-    let expected_2 = format!("• '{PAUSE}' and '{CONVERT_SELECTION}'\n");
-
-    assert!(err.contains(&expected_1), "{err}");
-    assert!(err.contains(&expected_2), "{err}");
-
-    let forbidden = format!("• '{CONVERT_LAST_WORD}' and '{CONVERT_SELECTION}'\n");
-    assert!(!err.contains(&forbidden), "{err}");
-}
-
-#[test]
 fn two_independent_duplicate_pairs_err_lists_both_in_stable_order() {
     let a = seq1(MOD_CONTROL.0, u32::from(b'A'));
     let b = seq1(MOD_ALT.0, u32::from(b'B'));
@@ -211,6 +194,7 @@ fn two_independent_duplicate_pairs_err_lists_both_in_stable_order() {
     let err = assert_err(mk_cfg(
         Some(a),
         Some(seq1(MOD_CONTROL.0, u32::from(b'A'))),
+        Some(seq1(MOD_SHIFT.0, u32::from(b'C'))),
         Some(b),
         Some(seq1(MOD_ALT.0, u32::from(b'B'))),
     ));
@@ -218,7 +202,7 @@ fn two_independent_duplicate_pairs_err_lists_both_in_stable_order() {
     assert_has_common_error_shape(&err);
 
     let expected = format!(
-        "Duplicate hotkey sequences found:\n\n• '{CONVERT_LAST_WORD}' and '{PAUSE}'\n• '{CONVERT_SELECTION}' and '{SWITCH_LAYOUT}'\n\nEach action must have a unique hotkey sequence."
+        "Duplicate hotkey sequences found:\n\n• '{CONVERT_LAST_WORD}' and '{CONVERT_LAST_SEQUENCE}'\n• '{CONVERT_SELECTION}' and '{SWITCH_LAYOUT}'\n\nEach action must have a unique hotkey sequence."
     );
 
     assert_eq!(err, expected);
@@ -232,6 +216,7 @@ fn duplicates_across_non_adjacent_actions_err() {
         Some(dup),
         None,
         Some(seq1(MOD_CONTROL.0, u32::from(b'A'))),
+        Some(seq1(MOD_ALT.0, u32::from(b'B'))),
         Some(seq1(MOD_SHIFT.0, u32::from(b'Z'))),
     ));
 
@@ -247,7 +232,7 @@ fn different_max_gap_is_not_duplicate_current_behavior() {
     let s1 = seq1_gap(MOD_CONTROL.0, u32::from(b'K'), 200);
     let s2 = seq1_gap(MOD_CONTROL.0, u32::from(b'K'), 400);
 
-    assert_ok(mk_cfg(Some(s1), Some(s2), None, None));
+    assert_ok(mk_cfg(Some(s1), Some(s2), None, None, None));
 }
 
 #[test]
@@ -255,7 +240,7 @@ fn different_mods_vks_is_not_duplicate_current_behavior() {
     let s1 = seq1_modsvks(MOD_CONTROL.0, 0, u32::from(b'K'));
     let s2 = seq1_modsvks(MOD_CONTROL.0, 1, u32::from(b'K'));
 
-    assert_ok(mk_cfg(Some(s1), Some(s2), None, None));
+    assert_ok(mk_cfg(Some(s1), Some(s2), None, None, None));
 }
 
 #[test]
@@ -275,7 +260,7 @@ fn different_second_chord_is_not_duplicate_current_behavior() {
         250,
     );
 
-    assert_ok(mk_cfg(Some(s1), Some(s2), None, None));
+    assert_ok(mk_cfg(Some(s1), Some(s2), None, None, None));
 }
 
 #[test]
@@ -299,11 +284,14 @@ fn same_two_chord_sequence_is_duplicate_err() {
         )),
         None,
         None,
+        None,
     ));
 
     assert_has_common_error_shape(&err);
     assert!(
-        err.contains(&format!("• '{CONVERT_LAST_WORD}' and '{PAUSE}'\n")),
+        err.contains(&format!(
+            "• '{CONVERT_LAST_WORD}' and '{CONVERT_LAST_SEQUENCE}'\n"
+        )),
         "{err}"
     );
 }
@@ -313,6 +301,7 @@ fn none_values_are_ignored_when_searching_duplicates() {
     let dup = seq1(MOD_ALT.0, u32::from(b'Q'));
 
     let err = assert_err(mk_cfg(
+        None,
         None,
         Some(dup),
         None,
@@ -333,13 +322,14 @@ fn error_message_includes_only_unique_pairs_once() {
         Some(seq1(MOD_CONTROL.0, u32::from(b'X'))),
         Some(seq1(MOD_CONTROL.0, u32::from(b'X'))),
         None,
+        None,
     ));
 
     let bullets: Vec<&str> = err.lines().filter(|l| l.starts_with("• '")).collect();
 
     assert_eq!(
         bullets.len(),
-        2,
-        "expected exactly 2 bullet lines, got {bullets:?}\n{err}"
+        3,
+        "expected exactly 3 bullet lines, got {bullets:?}\n{err}"
     );
 }

--- a/src/tests/on_hotkey_tests.rs
+++ b/src/tests/on_hotkey_tests.rs
@@ -2,8 +2,8 @@ use windows::Win32::Foundation::WPARAM;
 
 use crate::{
     input::hotkeys::{
-        HK_CONVERT_LAST_WORD_ID, HK_CONVERT_SELECTION_ID, HK_PAUSE_TOGGLE_ID, HK_SWITCH_LAYOUT_ID,
-        HotkeyAction, action_from_id,
+        HK_CONVERT_LAST_SEQUENCE_ID, HK_CONVERT_LAST_WORD_ID, HK_CONVERT_SELECTION_ID,
+        HK_PAUSE_TOGGLE_ID, HK_SWITCH_LAYOUT_ID, HotkeyAction, action_from_id,
     },
     platform::win::{hotkey_action_from_wparam, hotkey_id_from_wparam},
 };
@@ -13,6 +13,10 @@ fn hotkey_id_from_wparam_roundtrip() {
     assert_eq!(
         hotkey_id_from_wparam(WPARAM(HK_CONVERT_LAST_WORD_ID as usize)),
         HK_CONVERT_LAST_WORD_ID
+    );
+    assert_eq!(
+        hotkey_id_from_wparam(WPARAM(HK_CONVERT_LAST_SEQUENCE_ID as usize)),
+        HK_CONVERT_LAST_SEQUENCE_ID
     );
     assert_eq!(
         hotkey_id_from_wparam(WPARAM(HK_PAUSE_TOGGLE_ID as usize)),
@@ -33,6 +37,10 @@ fn action_from_id_known_values() {
     assert_eq!(
         action_from_id(HK_CONVERT_LAST_WORD_ID),
         Some(HotkeyAction::ConvertLastWord)
+    );
+    assert_eq!(
+        action_from_id(HK_CONVERT_LAST_SEQUENCE_ID),
+        Some(HotkeyAction::ConvertLastSequence)
     );
     assert_eq!(
         action_from_id(HK_PAUSE_TOGGLE_ID),
@@ -60,6 +68,10 @@ fn hotkey_action_from_wparam_known_values() {
     assert_eq!(
         hotkey_action_from_wparam(WPARAM(HK_CONVERT_LAST_WORD_ID as usize)),
         Some(HotkeyAction::ConvertLastWord)
+    );
+    assert_eq!(
+        hotkey_action_from_wparam(WPARAM(HK_CONVERT_LAST_SEQUENCE_ID as usize)),
+        Some(HotkeyAction::ConvertLastSequence)
     );
     assert_eq!(
         hotkey_action_from_wparam(WPARAM(HK_PAUSE_TOGGLE_ID as usize)),


### PR DESCRIPTION
## Summary
Serialize runtime hotkey/autoconvert execution through a single queue and tighten the last-word/last-sequence behavior with broader regression coverage.

## Problem
Hotkey actions were executed directly from asynchronous message delivery, so rapid alternation between commands like double Alt and double Shift could interleave badly. At the same time, the sequence journal logic had several edge-case regressions around mixed sequences, repeated toggles, and interactions between last-word and last-sequence commands.

## Solution
Introduce a queued runtime-command executor in the Win32 message path so hotkey and autoconvert actions run sequentially. Split last-word and last-sequence behavior explicitly, improve sequence journal extraction/update behavior for physical and programmatic tails, and add regression tests for cross-command scenarios and exact phrase cases.

## Scope
Included:
- separate last-word vs last-sequence bindings and behavior
- serialized runtime execution for hotkey/autoconvert commands
- sequence journal fixes and extraction updates
- GUI capture exit fixes and hotkey default updates
- expanded integration/regression tests across command interactions

Not included:
- full UI automation end-to-end tests
- broader redesign of Win32 input delivery beyond serialized command execution

## Validation
- `cargo +nightly fmt --check`
- `cargo +nightly test --locked`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `actionlint -color`
- `zizmor --min-severity medium .`

## Risks
The command queue and regression coverage close the in-process execution races we identified, but I did not run full GUI automation against a real desktop session. If there is any remaining issue, it is most likely a narrower Win32 timing/input-delivery case rather than missing core sequence logic.