### PR TITLE
Update pinned rust-toolchain workflow action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: nightly
           components: rustfmt
@@ -41,7 +41,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: nightly
           components: clippy
@@ -59,7 +59,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: nightly
       - name: Rust cache
@@ -76,7 +76,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust toolchain (nightly)
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: nightly
           components: rustfmt, clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Install Rust toolchain (nightly)
         if: steps.release_context.outputs.should_release == 'true'
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: nightly
           components: rustfmt, clippy


### PR DESCRIPTION
## Summary
Update the pinned `dtolnay/rust-toolchain` action SHA in CI and release workflows on top of current `dev`.

## Problem
Dependabot PR #105 is behind `dev`, and the repository still pins the older `dtolnay/rust-toolchain` revision in workflow files. The separate Dependabot PR #112 is stale because `tracing-appender 0.2.5` is already present on current `dev`.

## Solution
Apply the workflow pin update directly on top of the latest `dev` in a clean branch, preserving the existing workflow structure and only replacing the action SHA.

## Scope
Included: `.github/workflows/ci.yml` and `.github/workflows/release.yml` pin updates.
Not included: code changes, release version bump, or any additional dependency churn.

## Validation
- `actionlint -color`
- `zizmor --min-severity medium .`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`

## Risks
Remote GitHub Actions checks have not run yet on this replacement branch, so final CI status still depends on GitHub execution.