### PR TITLE
Sync v1.0.11 version bump back to dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -228,9 +228,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -273,7 +273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -293,9 +293,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -532,7 +532,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rust-switcher"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "confy",
  "embed-resource",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "rust-switcher-core"
-version = "1.0.10"
+version = "1.0.11"
 
 [[package]]
 name = "rustc_version"
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -963,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rust-switcher-core"]
 
 [package]
 name = "rust-switcher"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2024"
 
 description = "Windows keyboard layout switcher and text conversion utility"
@@ -15,7 +15,7 @@ keywords = ["windows", "winapi", "keyboard", "hotkey", "tray"]
 categories = ["gui", "os::windows-apis"]
 
 [dependencies]
-rust-switcher-core = { version = "1.0.10", path = "crates/rust-switcher-core" }
+rust-switcher-core = { version = "1.0.11", path = "crates/rust-switcher-core" }
 serde = { version = "1.0", features = ["derive"] }
 confy = "2.0"
 lingua = { version = "1.8", default-features = false, features = [
@@ -79,4 +79,5 @@ tracing-test = "0.2.6"
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.zip"
 bin-dir = "{ bin }{ binary-ext }"
+
 

--- a/crates/rust-switcher-core/Cargo.toml
+++ b/crates/rust-switcher-core/Cargo.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/qqrm/rust-switcher"
 description = "Core library for rust-switcher (Windows keyboard layout/typing conversion)."
 name = "rust-switcher-core"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2024"
 license = "MIT"
 readme = "../../README.md"


### PR DESCRIPTION
## Summary
Sync the already-published `v1.0.11` release version bump back into `dev`.

## Problem
The manual release workflow created tag `v1.0.11` and published the GitHub Release artifact, but the release script pushed only the tag, not the bump commit. That left `dev` at `1.0.10` while the published release is `1.0.11`.

## Solution
Cherry-pick the release bump commit from tag `v1.0.11` onto the current `dev` head so repository version metadata matches the published release.

## Scope
Included: `Cargo.toml`, `Cargo.lock`, and `crates/rust-switcher-core/Cargo.toml` version sync.
Not included: any functional code changes or workflow edits.

## Validation
- `actionlint -color`
- `zizmor --min-severity medium .`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`

## Risks
This PR intentionally syncs metadata after the release already shipped. The release artifact and tag already exist; merging this PR aligns `dev` with that published state.