### PR TITLE
Enable event-driven Dependabot auto-merge

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,8 +1,23 @@
 name: Auto merge
 
 on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only Dependabot auto-merge, no checkout or PR code execution
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
   schedule:
     - cron: "*/15 * * * *"
+  workflow_run: # zizmor: ignore[dangerous-triggers] retries enabling auto-merge after trusted workflow completions
+    workflows:
+      - CI
+      - Workflow Lint (actionlint)
+      - Spell Check (typos)
+      - GitHub Actions Security (zizmor)
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -15,6 +30,9 @@ concurrency:
 
 jobs:
   merge:
+    if: |
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -26,6 +44,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          is_dependabot_author() {
+            local author="$1"
+            [[ "$author" == "app/dependabot" || "$author" == "dependabot[bot]" ]]
+          }
 
           should_auto_merge() {
             local head_ref="$1"
@@ -48,27 +71,73 @@ jobs:
             return 0
           }
 
-          mapfile -t prs < <(
-            gh pr list \
-              --repo "$GH_REPO" \
-              --state open \
-              --limit 100 \
-              --json number,title,author,baseRefName,headRefName,mergeStateStatus \
-              --jq '.[] | select(.baseRefName == "dev" and .author.login == "app/dependabot" and (.headRefName | startswith("dependabot/"))) | [.number, .mergeStateStatus, .headRefName, (.title | @base64)] | @tsv'
-          )
+          collect_prs() {
+            case "$GITHUB_EVENT_NAME" in
+              pull_request_target)
+                jq -r '.pull_request.number' "$GITHUB_EVENT_PATH"
+                ;;
+              workflow_run)
+                jq -r '(.workflow_run.pull_requests // []) | .[].number' "$GITHUB_EVENT_PATH" | sort -u
+                ;;
+              *)
+                gh pr list \
+                  --repo "$GH_REPO" \
+                  --state open \
+                  --limit 100 \
+                  --json number,baseRefName,headRefName \
+                  --jq '.[] | select(.baseRefName == "dev" and (.headRefName | startswith("dependabot/"))) | .number'
+                ;;
+            esac
+          }
 
-          if [ "${#prs[@]}" -eq 0 ]; then
-            echo "No open Dependabot PRs found."
-            exit 0
-          fi
+          merge_pr() {
+            local pr="$1"
+            local pr_json
+            local author
+            local base_ref
+            local head_ref
+            local is_draft
+            local merge_state
+            local title
+            local merge_output
 
-          for entry in "${prs[@]}"; do
-            IFS=$'\t' read -r pr merge_state head_ref title_b64 <<<"$entry"
-            title="$(printf '%s' "$title_b64" | base64 --decode)"
+            pr_json="$(
+              gh pr view "$pr" \
+                --repo "$GH_REPO" \
+                --json number,title,author,baseRefName,headRefName,mergeStateStatus,isDraft \
+                --jq '{number: .number, title: .title, author: (.author.login // ""), baseRefName: .baseRefName, headRefName: .headRefName, mergeStateStatus: (.mergeStateStatus // ""), isDraft: .isDraft}'
+            )"
+
+            author="$(jq -r '.author' <<<"$pr_json")"
+            base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
+            head_ref="$(jq -r '.headRefName' <<<"$pr_json")"
+            is_draft="$(jq -r '.isDraft' <<<"$pr_json")"
+            merge_state="$(jq -r '.mergeStateStatus' <<<"$pr_json")"
+            title="$(jq -r '.title' <<<"$pr_json")"
+
+            if [ "$base_ref" != "dev" ]; then
+              echo "Skipping PR #$pr ($title): base branch is $base_ref, not dev."
+              return 0
+            fi
+
+            if ! is_dependabot_author "$author"; then
+              echo "Skipping PR #$pr ($title): author $author is not Dependabot."
+              return 0
+            fi
+
+            if [[ "$head_ref" != dependabot/* ]]; then
+              echo "Skipping PR #$pr ($title): head branch $head_ref is not a Dependabot branch."
+              return 0
+            fi
+
+            if [ "$is_draft" = "true" ]; then
+              echo "Skipping PR #$pr ($title): draft PR."
+              return 0
+            fi
 
             if ! should_auto_merge "$head_ref" "$title"; then
               echo "Skipping PR #$pr ($title): auto-merge policy requires cargo updates or non-major GitHub Actions bumps."
-              continue
+              return 0
             fi
 
             echo "Attempting to enable auto-merge for PR #$pr ($title)"
@@ -76,9 +145,31 @@ jobs:
               echo "PR #$pr is behind dev; updating branch first."
               gh pr update-branch "$pr" --repo "$GH_REPO"
             fi
-            if gh pr merge "$pr" --repo "$GH_REPO" --auto --squash --delete-branch; then
+
+            if merge_output="$(gh pr merge "$pr" --repo "$GH_REPO" --auto --squash --delete-branch 2>&1)"; then
               echo "Auto-merge is enabled for PR #$pr"
-            else
-              echo "PR #$pr is not ready for auto-merge yet; leaving it open for the next scan."
+              return 0
             fi
+
+            if grep -Fqi "auto-merge is already enabled" <<<"$merge_output"; then
+              echo "Auto-merge is already enabled for PR #$pr"
+              return 0
+            fi
+
+            echo "$merge_output"
+            echo "PR #$pr is not ready for auto-merge yet; leaving it open for the next trigger."
+          }
+
+          mapfile -t prs < <(collect_prs)
+
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "No candidate Dependabot PRs found for event $GITHUB_EVENT_NAME."
+            exit 0
+          fi
+
+          for pr in "${prs[@]}"; do
+            if [ -z "$pr" ]; then
+              continue
+            fi
+            merge_pr "$pr"
           done


### PR DESCRIPTION
## Summary
Switch Dependabot auto-merge from schedule-only polling to event-driven retries so eligible dependency bump PRs are queued for auto-merge as soon as they appear and after trusted checks finish.

## Problem
The existing auto-merge workflow only ran on `schedule` and `workflow_dispatch`. In practice that left green Dependabot PRs waiting for the next cron tick, and GitHub's scheduled workflow timing is not precise enough to give fast merges.

## Solution
Trigger the auto-merge workflow on `pull_request_target` for Dependabot PR metadata changes and on successful trusted `workflow_run` completions for the CI, actionlint, typos, and zizmor workflows. Keep the existing merge policy for cargo updates and non-major GitHub Actions bumps, and keep the workflow metadata-only with documented `zizmor` suppressions instead of checking out or executing PR code.

## Scope
Included: `.github/workflows/auto_merge.yml` trigger and selection logic updates.
Not included: changes to branch protection, Dependabot schedules, or release automation.

## Validation
- `actionlint -color`
- `zizmor --min-severity medium .`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`

## Risks
This still relies on privileged GitHub Actions triggers (`pull_request_target` and `workflow_run`) because normal `pull_request` runs cannot merge Dependabot PRs. The workflow remains metadata-only and does not check out or execute PR contents, but reviewers should still look closely at any future edits to this workflow.