### PR TITLE
Stage Dependabot auto-merge smoke test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+# Touching this file triggers an immediate Dependabot version update check after merge.
 updates:
   - package-ecosystem: "cargo"
     directory: "/"

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run typos
-        uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274
+        uses: crate-ci/typos@7c572958218557a3272c2d6719629443b5cc26fd


### PR DESCRIPTION
## Summary
Intentionally roll the `crate-ci/typos` action pin back one version and touch `dependabot.yml` so Dependabot immediately checks for updates after merge.

## Problem
The new event-driven Dependabot auto-merge workflow needs a live end-to-end verification path, but waiting for the next weekly GitHub Actions update window would not prove that it reacts promptly.

## Solution
Create a controlled, low-risk outdated GitHub Actions dependency on `dev` and update `dependabot.yml` with a no-op comment so GitHub immediately runs a Dependabot version update check after the change lands.

## Scope
Included: `.github/workflows/typos.yml` downgrade and a comment-only touch in `.github/dependabot.yml`.
Not included: any product code changes or cargo dependency churn.

## Validation
- `actionlint -color`
- `zizmor --min-severity medium .`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`

## Risks
This deliberately introduces a short-lived stale GitHub Actions pin into `dev` until Dependabot raises the follow-up PR and the auto-merge flow closes the loop.