### PR TITLE
Preserve conversion hotkeys after cursor movement

### DIFF
--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,46 @@
+# Interactive E2E
+
+These checks exercise the real Windows keyboard hook, foreground focus, and
+`SendInput` behavior in an isolated Windows Sandbox desktop.
+
+They are intentionally separate from normal unit tests because they require an
+interactive Windows session. A regular container or non-interactive service
+session cannot reliably validate `WH_KEYBOARD_LL`, foreground-window focus, or
+global input injection.
+
+## Run
+
+From the repository root:
+
+```powershell
+.\scripts\e2e\run-sandbox.ps1
+```
+
+The host script:
+
+1. Builds `rust-switcher.exe` with `debug-tracing`.
+2. Creates a temporary bundle under `%TEMP%`.
+3. Launches Windows Sandbox with that bundle mapped to the sandbox desktop.
+4. Runs `sandbox-runner.ps1` inside the sandbox.
+5. Waits for the sandbox to shut down and prints `result.json`.
+
+## Scenario Covered
+
+The current scenario validates the cursor-regression path:
+
+1. Start Rust Switcher with an isolated `%APPDATA%` and deterministic
+   `Shift+F12` convert hotkey.
+2. Open an isolated WinForms multiline `TextBox`.
+3. Type `ghbdtn world`.
+4. Press `Left` five times, putting the caret before `world`.
+5. Press `Shift+F12`.
+6. Assert the text becomes `привет world`.
+
+## Requirements
+
+- Windows 11 host.
+- Windows Sandbox feature enabled.
+- Rust nightly/MSVC available on the host for the build step.
+
+The sandbox is shut down automatically after the run. Use `-KeepOpen` while
+debugging the sandbox desktop.

--- a/scripts/e2e/run-sandbox.ps1
+++ b/scripts/e2e/run-sandbox.ps1
@@ -1,0 +1,88 @@
+param(
+    [switch]$KeepOpen,
+    [switch]$NoWait
+)
+
+$ErrorActionPreference = "Stop"
+
+function XmlEscape([string]$Value) {
+    return [System.Security.SecurityElement]::Escape($Value)
+}
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$sandboxExe = Join-Path $env:WINDIR "System32\WindowsSandbox.exe"
+if (-not (Test-Path $sandboxExe)) {
+    throw "Windows Sandbox is not available at $sandboxExe. Enable the Windows Sandbox optional feature first."
+}
+
+Push-Location $root
+try {
+    $env:CARGO_TARGET_DIR = ".target"
+    & cargo +nightly build --features debug-tracing
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo build failed with exit code $LASTEXITCODE"
+    }
+
+    $exe = Join-Path $root ".target\debug\rust-switcher.exe"
+    if (-not (Test-Path $exe)) {
+        throw "Built executable was not found at $exe"
+    }
+
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $bundle = Join-Path ([System.IO.Path]::GetTempPath()) "rust-switcher-e2e-$stamp"
+    New-Item -ItemType Directory -Path $bundle -Force | Out-Null
+
+    Copy-Item -LiteralPath $exe -Destination (Join-Path $bundle "rust-switcher.exe") -Force
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot "sandbox-runner.ps1") -Destination $bundle -Force
+
+    $leaf = Split-Path $bundle -Leaf
+    $guestRoot = "C:\Users\WDAGUtilityAccount\Desktop\$leaf"
+    $keepOpenArg = if ($KeepOpen) { " -KeepOpen" } else { "" }
+    $command = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$guestRoot\sandbox-runner.ps1`" -SharedRoot `"$guestRoot`"$keepOpenArg"
+
+    $wsb = Join-Path $bundle "rust-switcher-e2e.wsb"
+    $hostFolder = XmlEscape $bundle
+    $logonCommand = XmlEscape $command
+
+    @"
+<Configuration>
+  <MappedFolders>
+    <MappedFolder>
+      <HostFolder>$hostFolder</HostFolder>
+      <ReadOnly>false</ReadOnly>
+    </MappedFolder>
+  </MappedFolders>
+  <ClipboardRedirection>Disable</ClipboardRedirection>
+  <PrinterRedirection>Disable</PrinterRedirection>
+  <Networking>Disable</Networking>
+  <LogonCommand>
+    <Command>$logonCommand</Command>
+  </LogonCommand>
+</Configuration>
+"@ | Set-Content -LiteralPath $wsb -Encoding UTF8
+
+    Write-Host "Launching Windows Sandbox..."
+    Write-Host "Bundle: $bundle"
+
+    $proc = Start-Process -FilePath $sandboxExe -ArgumentList "`"$wsb`"" -PassThru
+    if ($NoWait) {
+        Write-Host "Sandbox started. Result will be written to $bundle\result.json"
+        return
+    }
+
+    $proc.WaitForExit()
+
+    $resultPath = Join-Path $bundle "result.json"
+    if (-not (Test-Path $resultPath)) {
+        throw "Sandbox exited without writing $resultPath. Check $bundle\e2e.log"
+    }
+
+    $result = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+    $result | ConvertTo-Json -Depth 8
+
+    if ($result.status -ne "passed") {
+        throw "Interactive E2E failed: $($result.error)"
+    }
+} finally {
+    Pop-Location
+}

--- a/scripts/e2e/sandbox-runner.ps1
+++ b/scripts/e2e/sandbox-runner.ps1
@@ -1,0 +1,192 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SharedRoot,
+
+    [switch]$KeepOpen
+)
+
+$ErrorActionPreference = "Stop"
+
+$logPath = Join-Path $SharedRoot "e2e.log"
+$resultPath = Join-Path $SharedRoot "result.json"
+$switcher = $null
+$form = $null
+
+function Write-Result {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Status,
+
+        [string]$ErrorMessage,
+
+        [hashtable]$Details = @{}
+    )
+
+    [ordered]@{
+        status = $Status
+        error = $ErrorMessage
+        details = $Details
+        timestampUtc = (Get-Date).ToUniversalTime().ToString("o")
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $resultPath -Encoding UTF8
+}
+
+function Pump-Ui {
+    param([int]$Milliseconds)
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($Milliseconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        [System.Windows.Forms.Application]::DoEvents()
+        Start-Sleep -Milliseconds 25
+    }
+}
+
+function Send-Keys-And-Pump {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Keys,
+
+        [int]$AfterMilliseconds = 250
+    )
+
+    [System.Windows.Forms.SendKeys]::SendWait($Keys)
+    Pump-Ui -Milliseconds $AfterMilliseconds
+}
+
+function Wait-For-Text {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Windows.Forms.TextBox]$TextBox,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Expected,
+
+        [int]$TimeoutMilliseconds = 5000
+    )
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMilliseconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        [System.Windows.Forms.Application]::DoEvents()
+        if ($TextBox.Text -eq $Expected) {
+            return $true
+        }
+        Start-Sleep -Milliseconds 50
+    }
+    return $false
+}
+
+try {
+    Start-Transcript -LiteralPath $logPath -Force | Out-Null
+
+    $exe = Join-Path $SharedRoot "rust-switcher.exe"
+    if (-not (Test-Path $exe)) {
+        throw "rust-switcher.exe is missing from $SharedRoot"
+    }
+
+    $appData = "C:\rust-switcher-e2e-appdata"
+    Remove-Item -LiteralPath $appData -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path (Join-Path $appData "RustSwitcher") -Force | Out-Null
+    $env:APPDATA = $appData
+    $env:RUST_LOG = "trace"
+
+    $config = [ordered]@{
+        delay_ms = 100
+        start_minimized = $true
+        theme_dark = $false
+        hotkey_convert_last_word = $null
+        hotkey_convert_selection = $null
+        hotkey_switch_layout = $null
+        hotkey_pause = $null
+        hotkey_convert_last_word_sequence = [ordered]@{
+            first = [ordered]@{
+                mods = 4
+                mods_vks = 0
+                vk = 123
+            }
+            second = $null
+            max_gap_ms = 1000
+        }
+        hotkey_pause_sequence = $null
+        hotkey_convert_selection_sequence = $null
+        hotkey_switch_layout_sequence = $null
+    }
+    $config | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $appData "RustSwitcher\config.json") -Encoding UTF8
+
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+
+    $english = [System.Windows.Forms.InputLanguage]::InstalledInputLanguages |
+        Where-Object { $_.Culture.TwoLetterISOLanguageName -eq "en" } |
+        Select-Object -First 1
+    if ($null -ne $english) {
+        [System.Windows.Forms.InputLanguage]::CurrentInputLanguage = $english
+    }
+
+    $switcher = Start-Process -FilePath $exe -WorkingDirectory $SharedRoot -PassThru
+    Start-Sleep -Milliseconds 1200
+
+    $form = New-Object System.Windows.Forms.Form
+    $form.Text = "Rust Switcher E2E Host"
+    $form.Width = 700
+    $form.Height = 220
+    $form.StartPosition = "CenterScreen"
+    $form.TopMost = $true
+
+    $textBox = New-Object System.Windows.Forms.TextBox
+    $textBox.Multiline = $true
+    $textBox.AcceptsReturn = $true
+    $textBox.AcceptsTab = $true
+    $textBox.Font = New-Object System.Drawing.Font("Consolas", 18)
+    $textBox.Dock = [System.Windows.Forms.DockStyle]::Fill
+    $form.Controls.Add($textBox)
+
+    $form.Show()
+    Pump-Ui -Milliseconds 500
+    $form.Activate()
+    $textBox.Focus()
+    Pump-Ui -Milliseconds 500
+
+    Send-Keys-And-Pump -Keys "ghbdtn world" -AfterMilliseconds 500
+    if ($textBox.Text -ne "ghbdtn world") {
+        throw "Initial typing failed. TextBox contains '$($textBox.Text)'"
+    }
+
+    Send-Keys-And-Pump -Keys "{LEFT 5}" -AfterMilliseconds 300
+    if ($textBox.SelectionStart -ne 7) {
+        throw "Caret setup failed. Expected SelectionStart=7, got $($textBox.SelectionStart)"
+    }
+
+    Send-Keys-And-Pump -Keys "+{F12}" -AfterMilliseconds 300
+    if (-not (Wait-For-Text -TextBox $textBox -Expected "привет world" -TimeoutMilliseconds 6000)) {
+        throw "Conversion failed. Expected 'привет world', got '$($textBox.Text)'"
+    }
+
+    if ($textBox.SelectionStart -ne 7) {
+        throw "Caret position changed unexpectedly. Expected SelectionStart=7, got $($textBox.SelectionStart)"
+    }
+
+    Write-Result -Status "passed" -Details @{
+        finalText = $textBox.Text
+        selectionStart = $textBox.SelectionStart
+        appData = $appData
+    }
+} catch {
+    Write-Result -Status "failed" -ErrorMessage $_.Exception.Message -Details @{
+        stack = $_.ScriptStackTrace
+    }
+    throw
+} finally {
+    if ($null -ne $switcher -and -not $switcher.HasExited) {
+        Stop-Process -Id $switcher.Id -Force -ErrorAction SilentlyContinue
+    }
+    if ($null -ne $form) {
+        $form.Close()
+        $form.Dispose()
+    }
+    try {
+        Stop-Transcript | Out-Null
+    } catch {
+    }
+    if (-not $KeepOpen) {
+        shutdown.exe /s /t 0 /f | Out-Null
+    }
+}

--- a/src/domain/text/last_word.rs
+++ b/src/domain/text/last_word.rs
@@ -493,6 +493,7 @@ struct LastRunPayload {
 }
 
 struct LastSequencePayload {
+    prefix_runs: Vec<InputRun>,
     runs: Vec<InputRun>,
     layout: LayoutTag,
     suffix_runs: Vec<InputRun>,
@@ -544,8 +545,55 @@ fn join_runs_text(runs: &[InputRun]) -> String {
     runs.iter().map(|run| run.text.as_str()).collect()
 }
 
+fn split_sequence_runs_for_conversion(
+    runs: Vec<InputRun>,
+    detector: &lingua::LanguageDetector,
+) -> (Vec<InputRun>, Vec<InputRun>) {
+    let Some(last_idx) = runs.iter().rposition(|run| run.kind == RunKind::Text) else {
+        return (Vec::new(), runs);
+    };
+
+    if runs[last_idx].origin == RunOrigin::Programmatic {
+        return (Vec::new(), runs);
+    }
+
+    let layout = runs[last_idx].layout;
+    let mut selected_start = last_idx;
+
+    for idx in (0..last_idx).rev() {
+        let run = &runs[idx];
+        if run.kind != RunKind::Text {
+            continue;
+        }
+        if should_include_previous_sequence_run(run, layout, detector) {
+            selected_start = idx;
+            continue;
+        }
+        break;
+    }
+
+    let mut runs = runs;
+    let selected_runs = runs.split_off(selected_start);
+    (runs, selected_runs)
+}
+
+fn should_include_previous_sequence_run(
+    run: &InputRun,
+    layout: LayoutTag,
+    detector: &lingua::LanguageDetector,
+) -> bool {
+    if !matches!(layout, LayoutTag::En | LayoutTag::Ru) {
+        return false;
+    }
+
+    let converted = convert_with_layout_fallback(&run.text, &layout);
+    should_autoconvert_word(detector, &run.text, &converted).is_ok()
+}
+
 fn take_last_sequence_payload() -> Option<LastSequencePayload> {
-    let (runs, suffix_runs) = crate::input_journal::take_last_layout_sequence_with_suffix()?;
+    let (raw_runs, suffix_runs) = crate::input_journal::take_last_layout_sequence_with_suffix()?;
+    let detector = language_detector();
+    let (prefix_runs, runs) = split_sequence_runs_for_conversion(raw_runs, detector);
     let last = runs.last()?;
     if last.kind != RunKind::Text {
         return None;
@@ -573,6 +621,7 @@ fn take_last_sequence_payload() -> Option<LastSequencePayload> {
     );
 
     Some(LastSequencePayload {
+        prefix_runs,
         runs,
         layout,
         suffix_runs,
@@ -640,12 +689,14 @@ fn flipped_layout(layout: LayoutTag) -> LayoutTag {
 }
 /// Updates the input journal to match what was inserted.
 fn restore_journal_original_sequence(p: &LastSequencePayload) {
+    crate::input_journal::push_runs(p.prefix_runs.iter().cloned());
     crate::input_journal::push_runs(p.runs.iter().cloned());
     crate::input_journal::push_runs(p.suffix_runs.iter().cloned());
     tracing::trace!("journal restored (original sequence metadata)");
 }
 
 fn update_journal_sequence(p: &LastSequencePayload, converted: &str) {
+    crate::input_journal::push_runs(p.prefix_runs.iter().cloned());
     crate::input_journal::push_text_with_meta(
         converted,
         flipped_layout(p.layout),
@@ -865,6 +916,7 @@ mod tests {
         assert_eq!(payload.layout, LayoutTag::En);
         assert_eq!(payload.seq_text, "ghbdtn rjynhjkm");
         assert_eq!(payload.suffix_text, "  ");
+        assert!(payload.prefix_runs.is_empty());
     }
 
     #[test]
@@ -909,6 +961,7 @@ mod tests {
         assert_eq!(p2.layout, LayoutTag::Ru);
         assert_eq!(p2.seq_text, "привет школа");
         assert!(p2.suffix_text.is_empty());
+        assert!(p2.prefix_runs.is_empty());
     }
 
     #[test]
@@ -1048,6 +1101,111 @@ mod tests {
         assert_eq!(runs[1].kind, RunKind::Whitespace);
         assert_eq!(runs[2].text, "школа");
         assert_eq!(runs[2].kind, RunKind::Text);
+    }
+
+    #[test]
+    fn last_sequence_payload_stops_before_previous_correct_english_word() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "hello".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        assert_eq!(payload.prefix_runs.len(), 2);
+        assert_eq!(payload.prefix_runs[0].text, "hello");
+        assert_eq!(payload.prefix_runs[1].text, " ");
+        assert_eq!(payload.seq_text, "ghbdtn");
+        assert_eq!(payload.layout, LayoutTag::En);
+    }
+
+    #[test]
+    fn last_sequence_payload_stops_before_previous_correct_russian_word() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "привет".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "руддщ".to_string(),
+                layout: LayoutTag::Ru,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        assert_eq!(payload.prefix_runs.len(), 2);
+        assert_eq!(payload.prefix_runs[0].text, "привет");
+        assert_eq!(payload.prefix_runs[1].text, " ");
+        assert_eq!(payload.seq_text, "руддщ");
+        assert_eq!(payload.layout, LayoutTag::Ru);
+    }
+
+    #[test]
+    fn update_journal_sequence_keeps_unconverted_prefix_runs() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "hello".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "ghbdtn".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        update_journal_sequence(&payload, "привет");
+
+        let runs = ring_buffer::runs_snapshot();
+        assert_eq!(runs.len(), 3);
+        assert_eq!(runs[0].text, "hello");
+        assert_eq!(runs[0].layout, LayoutTag::En);
+        assert_eq!(runs[1].text, " ");
+        assert_eq!(runs[1].kind, RunKind::Whitespace);
+        assert_eq!(runs[2].text, "привет");
+        assert_eq!(runs[2].layout, LayoutTag::Ru);
+        assert_eq!(runs[2].origin, RunOrigin::Programmatic);
     }
 
     #[test]

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -276,14 +276,17 @@ impl InputJournal {
         self.restore_suffix_after_caret(suffix_runs);
     }
 
+    #[cfg(any(test, windows))]
     fn move_caret_left(&mut self) {
         self.caret_from_end = self.caret_from_end.saturating_add(1).min(self.total_chars);
     }
 
+    #[cfg(any(test, windows))]
     fn move_caret_right(&mut self) {
         self.caret_from_end = self.caret_from_end.saturating_sub(1);
     }
 
+    #[cfg(windows)]
     fn move_caret_end(&mut self) {
         self.caret_from_end = 0;
     }

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -85,6 +85,7 @@ struct InputJournal {
     runs: VecDeque<InputRun>,
     cap_chars: usize,
     total_chars: usize,
+    caret_from_end: usize,
     last_token_autoconverted: bool,
     #[cfg(windows)]
     last_fg_hwnd: isize,
@@ -96,6 +97,7 @@ impl InputJournal {
             runs: VecDeque::new(),
             cap_chars,
             total_chars: 0,
+            caret_from_end: 0,
             last_token_autoconverted: false,
             #[cfg(windows)]
             last_fg_hwnd: 0,
@@ -106,10 +108,17 @@ impl InputJournal {
     fn clear(&mut self) {
         self.runs.clear();
         self.total_chars = 0;
+        self.caret_from_end = 0;
         self.last_token_autoconverted = false;
     }
 
-    fn append_segment(&mut self, text: &str, layout: LayoutTag, origin: RunOrigin, kind: RunKind) {
+    fn append_segment_end(
+        &mut self,
+        text: &str,
+        layout: LayoutTag,
+        origin: RunOrigin,
+        kind: RunKind,
+    ) {
         if text.is_empty() {
             return;
         }
@@ -133,6 +142,28 @@ impl InputJournal {
             kind,
         });
         self.enforce_cap_chars();
+    }
+
+    fn insert_run_before_caret(&mut self, run: InputRun) {
+        if run.text.is_empty() {
+            return;
+        }
+
+        let caret_from_end = self.caret_from_end.min(self.total_chars);
+        let suffix_runs = self.detach_suffix(caret_from_end);
+
+        self.append_segment_end(&run.text, run.layout, run.origin, run.kind);
+        self.restore_suffix_after_caret(suffix_runs);
+    }
+
+    fn restore_suffix_after_caret(&mut self, suffix_runs: Vec<InputRun>) {
+        let suffix_len = suffix_runs.iter().map(|run| run.text.chars().count()).sum();
+
+        for run in suffix_runs {
+            self.append_segment_end(&run.text, run.layout, run.origin, run.kind);
+        }
+
+        self.caret_from_end = suffix_len;
     }
 
     #[cfg(any(test, windows))]
@@ -161,7 +192,12 @@ impl InputJournal {
                 }
                 Some(k) if k == kind => {}
                 Some(k) => {
-                    self.append_segment(&text[start..i], layout, origin, k);
+                    self.insert_run_before_caret(InputRun {
+                        text: text[start..i].to_string(),
+                        layout,
+                        origin,
+                        kind: k,
+                    });
                     start = i;
                     current_kind = Some(kind);
                 }
@@ -169,12 +205,17 @@ impl InputJournal {
         }
 
         if let Some(kind) = current_kind {
-            self.append_segment(&text[start..], layout, origin, kind);
+            self.insert_run_before_caret(InputRun {
+                text: text[start..].to_string(),
+                layout,
+                origin,
+                kind,
+            });
         }
     }
 
     fn push_run(&mut self, run: InputRun) {
-        self.append_segment(&run.text, run.layout, run.origin, run.kind);
+        self.insert_run_before_caret(run);
     }
 
     fn push_runs(&mut self, runs: impl IntoIterator<Item = InputRun>) {
@@ -208,10 +249,14 @@ impl InputJournal {
                 let _ = self.runs.pop_front();
             }
         }
+
+        self.caret_from_end = self.caret_from_end.min(self.total_chars);
     }
 
     #[cfg(any(test, windows))]
     fn backspace(&mut self) {
+        let caret_from_end = self.caret_from_end.min(self.total_chars);
+        let suffix_runs = self.detach_suffix(caret_from_end);
         let mut pop_last = false;
 
         if let Some(last) = self.runs.back_mut()
@@ -227,6 +272,60 @@ impl InputJournal {
         if pop_last {
             let _ = self.runs.pop_back();
         }
+
+        self.restore_suffix_after_caret(suffix_runs);
+    }
+
+    fn move_caret_left(&mut self) {
+        self.caret_from_end = self.caret_from_end.saturating_add(1).min(self.total_chars);
+    }
+
+    fn move_caret_right(&mut self) {
+        self.caret_from_end = self.caret_from_end.saturating_sub(1);
+    }
+
+    fn move_caret_end(&mut self) {
+        self.caret_from_end = 0;
+    }
+
+    fn detach_suffix(&mut self, count: usize) -> Vec<InputRun> {
+        let mut remaining = count.min(self.total_chars);
+        let mut suffix_rev = Vec::new();
+
+        while remaining > 0 {
+            let Some(mut run) = self.runs.pop_back() else {
+                self.total_chars = 0;
+                break;
+            };
+
+            let run_len = run.text.chars().count();
+            if run_len <= remaining {
+                self.total_chars = self.total_chars.saturating_sub(run_len);
+                remaining -= run_len;
+                suffix_rev.push(run);
+                continue;
+            }
+
+            let split_chars = run_len - remaining;
+            let Some((split_idx, _)) = run.text.char_indices().nth(split_chars) else {
+                self.runs.push_back(run);
+                break;
+            };
+            let suffix_text = run.text.split_off(split_idx);
+            let suffix_run = InputRun {
+                text: suffix_text,
+                layout: run.layout,
+                origin: run.origin,
+                kind: run.kind,
+            };
+            self.runs.push_back(run);
+            self.total_chars = self.total_chars.saturating_sub(remaining);
+            suffix_rev.push(suffix_run);
+            remaining = 0;
+        }
+
+        suffix_rev.reverse();
+        suffix_rev
     }
 
     #[cfg(windows)]
@@ -252,72 +351,91 @@ impl InputJournal {
 
     #[cfg(any(test, windows))]
     fn last_char(&self) -> Option<char> {
-        self.runs.back()?.text.chars().last()
+        self.chars_before_caret_rev().next()
     }
 
     #[cfg(any(test, windows))]
     fn prev_char_before_last(&self) -> Option<char> {
-        let mut runs_it = self.runs.iter().rev();
-        let last_run = runs_it.next()?;
+        self.chars_before_caret_rev().nth(1)
+    }
 
-        let mut chars = last_run.text.chars().rev();
-        let _ = chars.next()?;
-        if let Some(prev) = chars.next() {
-            return Some(prev);
-        }
-
-        for run in runs_it {
-            if let Some(ch) = run.text.chars().last() {
-                return Some(ch);
-            }
-        }
-
-        None
+    #[cfg(any(test, windows))]
+    fn chars_before_caret_rev(&self) -> impl Iterator<Item = char> + '_ {
+        let prefix_len = self.total_chars.saturating_sub(self.caret_from_end);
+        self.runs
+            .iter()
+            .flat_map(|run| run.text.chars())
+            .take(prefix_len)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
     }
 
     fn take_last_layout_run_with_suffix(&mut self) -> Option<(InputRun, Vec<InputRun>)> {
+        let caret_from_end = self.caret_from_end.min(self.total_chars);
+        let suffix_after_caret = self.detach_suffix(caret_from_end);
+        self.caret_from_end = 0;
+
         let mut suffix_runs = self.pop_suffix_whitespace();
 
-        if self.runs.back().is_none_or(|run| run.kind != RunKind::Text) {
+        let result = if self.runs.back().is_none_or(|run| run.kind != RunKind::Text) {
             self.restore_suffix(&mut suffix_runs);
-            return None;
-        }
+            None
+        } else if let Some(run) = self.runs.pop_back() {
+            self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
+            suffix_runs.reverse();
+            Some((run, suffix_runs))
+        } else {
+            self.restore_suffix(&mut suffix_runs);
+            None
+        };
 
-        let run = self.runs.pop_back()?;
-        self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
-        suffix_runs.reverse();
-        Some((run, suffix_runs))
+        self.restore_suffix_after_caret(suffix_after_caret);
+        result
     }
 
     fn take_last_layout_sequence_with_suffix(&mut self) -> Option<(Vec<InputRun>, Vec<InputRun>)> {
+        let caret_from_end = self.caret_from_end.min(self.total_chars);
+        let suffix_after_caret = self.detach_suffix(caret_from_end);
+        self.caret_from_end = 0;
+
         let mut suffix_runs = self.pop_suffix_whitespace();
 
-        if self.runs.back().is_none_or(|run| run.kind != RunKind::Text) {
+        let result = if self.runs.back().is_none_or(|run| run.kind != RunKind::Text) {
             self.restore_suffix(&mut suffix_runs);
-            return None;
-        }
-
-        let last = self.runs.back()?;
-        let target_layout = last.layout;
-        let target_origin = last.origin;
-        let mut seq_rev: Vec<InputRun> = Vec::new();
-        while let Some(run) = self.runs.back() {
-            if run.layout != target_layout || run.origin != target_origin {
-                break;
+            None
+        } else {
+            let Some(last) = self.runs.back() else {
+                self.restore_suffix(&mut suffix_runs);
+                self.restore_suffix_after_caret(suffix_after_caret);
+                return None;
+            };
+            let target_layout = last.layout;
+            let target_origin = last.origin;
+            let mut seq_rev: Vec<InputRun> = Vec::new();
+            while let Some(run) = self.runs.back() {
+                if run.layout != target_layout || run.origin != target_origin {
+                    break;
+                }
+                let Some(run) = self.runs.pop_back() else {
+                    break;
+                };
+                self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
+                seq_rev.push(run);
             }
-            let run = self.runs.pop_back()?;
-            self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
-            seq_rev.push(run);
-        }
 
-        if seq_rev.is_empty() {
-            self.restore_suffix(&mut suffix_runs);
-            return None;
-        }
+            if seq_rev.is_empty() {
+                self.restore_suffix(&mut suffix_runs);
+                None
+            } else {
+                seq_rev.reverse();
+                suffix_runs.reverse();
+                Some((seq_rev, suffix_runs))
+            }
+        };
 
-        seq_rev.reverse();
-        suffix_runs.reverse();
-        Some((seq_rev, suffix_runs))
+        self.restore_suffix_after_caret(suffix_after_caret);
+        result
     }
 
     fn pop_suffix_whitespace(&mut self) -> Vec<InputRun> {
@@ -524,6 +642,9 @@ pub fn record_keydown(kb: &KBDLLHOOKSTRUCT, vk: u32) -> Option<String> {
     enum JournalAction {
         Clear,
         Backspace,
+        MoveCaretLeft,
+        MoveCaretRight,
+        MoveCaretEnd,
         PushText {
             text: String,
             layout: LayoutTag,
@@ -535,8 +656,12 @@ pub fn record_keydown(kb: &KBDLLHOOKSTRUCT, vk: u32) -> Option<String> {
     let mut output: Option<String> = None;
 
     match vk {
-        VK_ESCAPE | VK_DELETE | VK_INSERT | VK_LEFT | VK_RIGHT | VK_UP | VK_DOWN | VK_HOME
-        | VK_END | VK_PRIOR | VK_NEXT => action = Some(JournalAction::Clear),
+        VK_ESCAPE | VK_DELETE | VK_INSERT | VK_UP | VK_DOWN | VK_HOME | VK_PRIOR | VK_NEXT => {
+            action = Some(JournalAction::Clear);
+        }
+        VK_LEFT => action = Some(JournalAction::MoveCaretLeft),
+        VK_RIGHT => action = Some(JournalAction::MoveCaretRight),
+        VK_END => action = Some(JournalAction::MoveCaretEnd),
         VK_BACK => action = Some(JournalAction::Backspace),
         VK_RETURN => {
             let layout = current_foreground_layout_tag();
@@ -579,6 +704,9 @@ pub fn record_keydown(kb: &KBDLLHOOKSTRUCT, vk: u32) -> Option<String> {
             match action {
                 JournalAction::Clear => j.clear(),
                 JournalAction::Backspace => j.backspace(),
+                JournalAction::MoveCaretLeft => j.move_caret_left(),
+                JournalAction::MoveCaretRight => j.move_caret_right(),
+                JournalAction::MoveCaretEnd => j.move_caret_end(),
                 JournalAction::PushText {
                     text,
                     layout,
@@ -627,6 +755,24 @@ pub fn push_text_with_meta(text: &str, layout: LayoutTag, origin: RunOrigin) {
 #[cfg(test)]
 pub fn test_backspace() {
     with_journal_mut(|j| j.backspace());
+}
+
+#[cfg(test)]
+pub fn test_move_caret_left(count: usize) {
+    with_journal_mut(|j| {
+        for _ in 0..count {
+            j.move_caret_left();
+        }
+    });
+}
+
+#[cfg(test)]
+pub fn test_move_caret_right(count: usize) {
+    with_journal_mut(|j| {
+        for _ in 0..count {
+            j.move_caret_right();
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src/tests/ring_buffer_tests.rs
+++ b/src/tests/ring_buffer_tests.rs
@@ -9,6 +9,13 @@ fn test_lock() -> MutexGuard<'static, ()> {
         .unwrap_or_else(|e| e.into_inner())
 }
 
+fn journal_text() -> String {
+    ring_buffer::runs_snapshot()
+        .iter()
+        .map(|r| r.text.as_str())
+        .collect()
+}
+
 #[test]
 fn run_journal_merges_contiguous_same_metadata() {
     let _guard = test_lock();
@@ -133,6 +140,132 @@ fn backspace_removes_from_last_run_and_drops_empty_run() {
     ring_buffer::push_text("a");
     ring_buffer::test_backspace();
     assert!(ring_buffer::take_last_layout_run_with_suffix().is_none());
+}
+
+#[test]
+fn caret_left_keeps_last_run_before_caret_available() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("ghbdtn world");
+
+    ring_buffer::test_move_caret_left(5);
+
+    let (run, suffix) = ring_buffer::take_last_layout_run_with_suffix().expect("payload");
+    assert_eq!(run.text, "ghbdtn");
+    assert_eq!(
+        suffix.iter().map(|r| r.text.as_str()).collect::<String>(),
+        " "
+    );
+
+    ring_buffer::push_run(run);
+    ring_buffer::push_runs(suffix);
+    assert_eq!(journal_text(), "ghbdtn world");
+}
+
+#[test]
+fn caret_left_keeps_last_sequence_before_caret_available() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("ghbdtn rjynhjkm done");
+
+    ring_buffer::test_move_caret_left(4);
+
+    let (runs, suffix) = ring_buffer::take_last_layout_sequence_with_suffix().expect("payload");
+    assert_eq!(
+        runs.iter().map(|r| r.text.as_str()).collect::<String>(),
+        "ghbdtn rjynhjkm"
+    );
+    assert_eq!(
+        suffix.iter().map(|r| r.text.as_str()).collect::<String>(),
+        " "
+    );
+}
+
+#[test]
+fn caret_right_moves_back_toward_journal_end() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("one two");
+
+    ring_buffer::test_move_caret_left(5);
+    ring_buffer::test_move_caret_right(5);
+
+    let (run, suffix) = ring_buffer::take_last_layout_run_with_suffix().expect("payload");
+    assert_eq!(run.text, "two");
+    assert!(suffix.is_empty());
+}
+
+#[test]
+fn typing_after_caret_left_inserts_before_suffix() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("abef");
+
+    ring_buffer::test_move_caret_left(2);
+    ring_buffer::push_text("cd");
+
+    assert_eq!(journal_text(), "abcdef");
+}
+
+#[test]
+fn backspace_after_caret_left_removes_before_caret() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("abcdef");
+
+    ring_buffer::test_move_caret_left(2);
+    ring_buffer::test_backspace();
+
+    assert_eq!(journal_text(), "abcef");
+}
+
+#[test]
+fn caret_left_insertion_preserves_utf8_boundaries() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("привмир");
+
+    ring_buffer::test_move_caret_left(3);
+    ring_buffer::push_text("ет ");
+
+    assert_eq!(journal_text(), "привет мир");
+}
+
+#[test]
+fn excessive_caret_left_clamps_to_start() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("tail");
+
+    ring_buffer::test_move_caret_left(999);
+    ring_buffer::push_text("head ");
+
+    assert_eq!(journal_text(), "head tail");
+}
+
+#[test]
+fn replacement_after_caret_left_preserves_suffix_after_caret() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("ghbdtn world");
+
+    ring_buffer::test_move_caret_left(5);
+    let (_run, suffix) = ring_buffer::take_last_layout_run_with_suffix().expect("payload");
+    ring_buffer::push_text("привет");
+    ring_buffer::push_runs(suffix);
+
+    assert_eq!(journal_text(), "привет world");
+}
+
+#[test]
+fn autoconvert_trigger_uses_character_before_caret() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_text("abc def");
+
+    ring_buffer::test_move_caret_left(3);
+
+    assert!(ring_buffer::last_char_triggers_autoconvert());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Preserve the input journal around Left/Right cursor movement so convert-last-sequence works before the current caret, not only at the journal end.
- Add regression coverage for cursor movement, mid-buffer insertion/backspace, UTF-8 boundaries, suffix preservation, and autoconvert triggers before the caret.
- Add a Windows Sandbox interactive E2E harness for isolated desktop validation of the real keyboard hook and SendInput path.

## Problem
Cursor navigation cleared the input journal, so convert word/sequence hotkeys stopped working after moving the caret backward or forward.

## Solution
The journal now tracks caret distance from the end, detaches/restores suffix runs around that caret, and extracts the last run/sequence before the caret while preserving text after it. Left/Right update the tracked caret position, End returns it to the journal end, and unsafe navigation keys still clear the journal.

## Scope
Included: input journal cursor tracking, regression tests, and an isolated Windows Sandbox E2E harness.

Not included: version bump, release packaging, or a completed sandbox run on this host because Windows Sandbox is not installed/enabled here.

## Validation
- `cargo +nightly fmt --check`
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly build --features debug-tracing`
- `cargo +nightly test --locked`
- `cargo +nightly build --release --locked`
- `actionlint -color`
- `zizmor --min-severity medium .`
- `git diff --check`
- PowerShell parse check for `scripts/e2e/run-sandbox.ps1` and `scripts/e2e/sandbox-runner.ps1`
- `scripts/e2e/run-sandbox.ps1 -NoWait` was attempted and correctly reported missing Windows Sandbox on this host.

## Risks
The true interactive E2E scenario still needs to run on a Windows host with Windows Sandbox enabled. Home/Up/Down/Page navigation still invalidates the journal because the hook cannot reliably infer arbitrary line/document positions without a focused-control integration.
