### PR TITLE
Preserve phrase buffer after word conversion

### DIFF
--- a/src/domain/text/last_word.rs
+++ b/src/domain/text/last_word.rs
@@ -40,11 +40,14 @@ fn convert_with_layout_fallback(text: &str, layout: &LayoutTag) -> String {
     convert_ru_en_with_direction(text, direction)
 }
 
-fn convert_sequence_runs(runs: &[InputRun]) -> String {
+fn convert_sequence_runs(runs: &[InputRun], keep_programmatic_text: bool) -> String {
     let mut out = String::new();
 
     for run in runs {
         match run.kind {
+            RunKind::Text if keep_programmatic_text && run.origin == RunOrigin::Programmatic => {
+                out.push_str(&run.text);
+            }
             RunKind::Text => out.push_str(&convert_with_layout_fallback(&run.text, &run.layout)),
             RunKind::Whitespace => out.push_str(&run.text),
         }
@@ -506,7 +509,7 @@ fn convert_last_sequence_impl(state: &mut AppState, switch_layout: bool) {
         tracing::trace!("newline present, skipping convert_last_sequence");
         return;
     }
-    let converted = convert_sequence_runs(&payload.runs);
+    let converted = convert_sequence_runs(&payload.runs, payload.keep_programmatic_text);
     tracing::trace!(%converted, "converted");
     if apply_last_sequence_conversion(&payload, &converted) {
         update_journal_sequence(&payload, &converted);
@@ -555,6 +558,7 @@ struct LastSequencePayload {
     suffix_spaces_only: bool,
     suffix_has_newline: bool,
     seq_has_newline: bool,
+    keep_programmatic_text: bool,
 }
 fn suffix_text_and_meta(suffix_runs: &[InputRun]) -> (String, usize, bool, bool) {
     let text: String = suffix_runs.iter().map(|run| run.text.as_str()).collect();
@@ -597,9 +601,7 @@ fn join_runs_text(runs: &[InputRun]) -> String {
 }
 
 fn take_last_sequence_payload() -> Option<LastSequencePayload> {
-    let (runs, suffix_runs) =
-        crate::input_journal::take_last_programmatic_sequence_with_suffix()
-            .or_else(crate::input_journal::take_last_layout_sequence_with_suffix)?;
+    let (runs, suffix_runs) = crate::input_journal::take_last_sequence_with_suffix()?;
     let last = runs.last()?;
     if last.kind != RunKind::Text {
         return None;
@@ -613,6 +615,9 @@ fn take_last_sequence_payload() -> Option<LastSequencePayload> {
         suffix_text_and_meta(&suffix_runs);
     let seq_len = seq_text.chars().count();
     let seq_has_newline = seq_text.contains('\n') || seq_text.contains('\r');
+    let has_physical = runs.iter().any(|run| run.origin == RunOrigin::Physical);
+    let has_programmatic = runs.iter().any(|run| run.origin == RunOrigin::Programmatic);
+    let keep_programmatic_text = has_physical && has_programmatic;
 
     tracing::trace!(
         seq_text = %seq_text,
@@ -623,6 +628,7 @@ fn take_last_sequence_payload() -> Option<LastSequencePayload> {
         suffix_spaces_only,
         suffix_has_newline,
         seq_has_newline,
+        keep_programmatic_text,
         "journal extracted sequence"
     );
 
@@ -638,6 +644,7 @@ fn take_last_sequence_payload() -> Option<LastSequencePayload> {
         suffix_spaces_only,
         suffix_has_newline,
         seq_has_newline,
+        keep_programmatic_text,
     })
 }
 
@@ -706,6 +713,9 @@ fn update_journal_sequence(p: &LastSequencePayload, converted: &str) {
     crate::input_journal::push_runs(p.runs.iter().map(|run| {
         let text = match run.kind {
             RunKind::Whitespace => run.text.clone(),
+            RunKind::Text if p.keep_programmatic_text && run.origin == RunOrigin::Programmatic => {
+                run.text.clone()
+            }
             RunKind::Text => convert_with_layout_fallback(&run.text, &run.layout),
         };
 
@@ -761,7 +771,7 @@ fn repeat_tap(vk: VIRTUAL_KEY, count: usize, err_msg: &'static str) -> bool {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
-    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::sync::MutexGuard;
 
     use lingua::{Language, LanguageDetectorBuilder};
 
@@ -769,10 +779,7 @@ mod tests {
     use crate::input::ring_buffer;
 
     fn test_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        ring_buffer::test_guard()
     }
     fn detector_ru_en() -> lingua::LanguageDetector {
         LanguageDetectorBuilder::from_languages(&[Language::Russian, Language::English])
@@ -1050,7 +1057,7 @@ mod tests {
         assert_eq!(p1.seq_text, "ghbdtn rjynhjkm");
 
         // Simulate manual conversion journal update (programmatic RU)
-        let c1 = convert_sequence_runs(&p1.runs);
+        let c1 = convert_sequence_runs(&p1.runs, p1.keep_programmatic_text);
         update_journal_sequence(&p1, &c1);
 
         // Second extraction must succeed (programmatic RU), enabling toggle-back.
@@ -1088,12 +1095,12 @@ mod tests {
         ]);
 
         let p1 = take_last_sequence_payload().expect("first sequence payload expected");
-        let c1 = convert_sequence_runs(&p1.runs);
+        let c1 = convert_sequence_runs(&p1.runs, p1.keep_programmatic_text);
         assert_ne!(c1, p1.seq_text);
         update_journal_sequence(&p1, &c1);
 
         let p2 = take_last_sequence_payload().expect("second sequence payload expected");
-        let c2 = convert_sequence_runs(&p2.runs);
+        let c2 = convert_sequence_runs(&p2.runs, p2.keep_programmatic_text);
         update_journal_sequence(&p2, &c2);
 
         let p3 = take_last_sequence_payload().expect("third sequence payload expected");
@@ -1217,7 +1224,7 @@ mod tests {
 
         let payload = take_last_sequence_payload().expect("sequence payload expected");
         assert_eq!(payload.suffix_text, "  ");
-        let converted = convert_sequence_runs(&payload.runs);
+        let converted = convert_sequence_runs(&payload.runs, payload.keep_programmatic_text);
         update_journal_sequence(&payload, &converted);
 
         let next = take_last_sequence_payload().expect("sequence payload after update expected");
@@ -1252,7 +1259,7 @@ mod tests {
         ]);
 
         let payload = take_last_sequence_payload().expect("sequence payload expected");
-        let converted = convert_sequence_runs(&payload.runs);
+        let converted = convert_sequence_runs(&payload.runs, payload.keep_programmatic_text);
         update_journal_sequence(&payload, &converted);
 
         let (runs, suffix) =
@@ -1465,7 +1472,7 @@ mod tests {
         ]);
 
         let seq = take_last_sequence_payload().expect("sequence payload expected");
-        let converted = convert_sequence_runs(&seq.runs);
+        let converted = convert_sequence_runs(&seq.runs, seq.keep_programmatic_text);
         update_journal_sequence(&seq, &converted);
 
         let word = take_last_word_payload().expect("word payload expected");
@@ -1475,7 +1482,7 @@ mod tests {
     }
 
     #[test]
-    fn last_sequence_after_last_word_update_targets_only_last_programmatic_word() {
+    fn last_sequence_after_last_word_update_preserves_full_phrase_buffer() {
         let _guard = test_lock();
         ring_buffer::invalidate();
         ring_buffer::push_runs([
@@ -1504,8 +1511,13 @@ mod tests {
         update_journal(&word, &converted);
 
         let seq = take_last_sequence_payload().expect("sequence payload expected");
-        assert_eq!(seq.seq_text, "контроль");
+        assert_eq!(seq.seq_text, "ghbdtn контроль");
         assert_eq!(seq.layout, LayoutTag::Ru);
+        assert!(seq.keep_programmatic_text);
+        assert_eq!(
+            convert_sequence_runs(&seq.runs, seq.keep_programmatic_text),
+            "привет контроль"
+        );
         assert!(seq.prefix_runs.is_empty());
     }
 
@@ -1535,7 +1547,7 @@ mod tests {
         ]);
 
         let seq = take_last_sequence_payload().expect("sequence payload expected");
-        let converted = convert_sequence_runs(&seq.runs);
+        let converted = convert_sequence_runs(&seq.runs, seq.keep_programmatic_text);
         update_journal_sequence(&seq, &converted);
 
         ring_buffer::push_run(InputRun {
@@ -1590,7 +1602,61 @@ mod tests {
 
         let payload = take_last_sequence_payload().expect("sequence payload expected");
         assert_eq!(payload.seq_text, "hfp ldf nhb");
-        assert_eq!(convert_sequence_runs(&payload.runs), "раз два три");
+        assert_eq!(
+            convert_sequence_runs(&payload.runs, payload.keep_programmatic_text),
+            "раз два три"
+        );
+    }
+
+    #[test]
+    fn exact_phrase_hfp_ldf_nhb_stays_full_sequence_after_last_word_update() {
+        let _guard = test_lock();
+        ring_buffer::invalidate();
+        ring_buffer::push_runs([
+            InputRun {
+                text: "hfp".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "ldf".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+            InputRun {
+                text: " ".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Whitespace,
+            },
+            InputRun {
+                text: "nhb".to_string(),
+                layout: LayoutTag::En,
+                origin: RunOrigin::Physical,
+                kind: RunKind::Text,
+            },
+        ]);
+
+        let word = take_last_word_payload().expect("word payload expected");
+        let converted_word = convert_with_layout_fallback(&word.run.text, &word.run.layout);
+        assert_eq!(converted_word, "три");
+        update_journal(&word, &converted_word);
+
+        let payload = take_last_sequence_payload().expect("sequence payload expected");
+        assert_eq!(payload.seq_text, "hfp ldf три");
+        assert!(payload.keep_programmatic_text);
+        assert_eq!(
+            convert_sequence_runs(&payload.runs, payload.keep_programmatic_text),
+            "раз два три"
+        );
     }
 
     #[test]

--- a/src/input/ring_buffer.rs
+++ b/src/input/ring_buffer.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::sync::MutexGuard;
 use std::{
     collections::VecDeque,
     sync::{Mutex, OnceLock},
@@ -18,8 +20,19 @@ use windows::Win32::UI::{
 
 static JOURNAL: OnceLock<Mutex<InputJournal>> = OnceLock::new();
 
+#[cfg(test)]
+static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
 fn journal() -> &'static Mutex<InputJournal> {
     JOURNAL.get_or_init(|| Mutex::new(InputJournal::new(100)))
+}
+
+#[cfg(test)]
+pub fn test_guard() -> MutexGuard<'static, ()> {
+    TEST_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
 }
 
 fn with_journal_mut<R>(f: impl FnOnce(&mut InputJournal) -> R) -> R {
@@ -397,6 +410,7 @@ impl InputJournal {
         result
     }
 
+    #[cfg(test)]
     fn take_last_layout_sequence_with_suffix(&mut self) -> Option<(Vec<InputRun>, Vec<InputRun>)> {
         let caret_from_end = self.caret_from_end.min(self.total_chars);
         let suffix_after_caret = self.detach_suffix(caret_from_end);
@@ -441,6 +455,7 @@ impl InputJournal {
         result
     }
 
+    #[cfg(test)]
     fn take_last_programmatic_sequence_with_suffix(
         &mut self,
     ) -> Option<(Vec<InputRun>, Vec<InputRun>)> {
@@ -482,6 +497,69 @@ impl InputJournal {
 
         self.restore_suffix_after_caret(suffix_after_caret);
         result
+    }
+
+    fn take_last_sequence_with_suffix(&mut self) -> Option<(Vec<InputRun>, Vec<InputRun>)> {
+        let mut suffix_runs = self.pop_suffix_whitespace();
+
+        if self.runs.back().is_none_or(|run| run.kind != RunKind::Text) {
+            self.restore_suffix(&mut suffix_runs);
+            return None;
+        }
+
+        let mut seq_rev = Vec::new();
+        let last = self.runs.back()?;
+
+        if last.origin == RunOrigin::Programmatic {
+            while self
+                .runs
+                .back()
+                .is_some_and(|run| run.origin == RunOrigin::Programmatic)
+            {
+                let run = self.runs.pop_back()?;
+                self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
+                seq_rev.push(run);
+            }
+
+            let prefix_layout = self
+                .runs
+                .iter()
+                .rev()
+                .find(|run| run.origin == RunOrigin::Physical && run.kind == RunKind::Text)
+                .map(|run| run.layout);
+
+            if let Some(layout) = prefix_layout {
+                while self
+                    .runs
+                    .back()
+                    .is_some_and(|run| run.origin == RunOrigin::Physical && run.layout == layout)
+                {
+                    let run = self.runs.pop_back()?;
+                    self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
+                    seq_rev.push(run);
+                }
+            }
+        } else {
+            let target_layout = last.layout;
+            let target_origin = last.origin;
+            while let Some(run) = self.runs.back() {
+                if run.layout != target_layout || run.origin != target_origin {
+                    break;
+                }
+                let run = self.runs.pop_back()?;
+                self.total_chars = self.total_chars.saturating_sub(run.text.chars().count());
+                seq_rev.push(run);
+            }
+        }
+
+        if seq_rev.is_empty() {
+            self.restore_suffix(&mut suffix_runs);
+            return None;
+        }
+
+        seq_rev.reverse();
+        suffix_runs.reverse();
+        Some((seq_rev, suffix_runs))
     }
 
     fn pop_suffix_whitespace(&mut self) -> Vec<InputRun> {
@@ -785,14 +863,21 @@ pub fn take_last_layout_run_with_suffix() -> Option<(InputRun, Vec<InputRun>)> {
     with_journal_mut(|j| j.take_last_layout_run_with_suffix())
 }
 
+#[cfg(test)]
 #[must_use]
 pub fn take_last_layout_sequence_with_suffix() -> Option<(Vec<InputRun>, Vec<InputRun>)> {
     with_journal_mut(|j| j.take_last_layout_sequence_with_suffix())
 }
 
+#[cfg(test)]
 #[must_use]
 pub fn take_last_programmatic_sequence_with_suffix() -> Option<(Vec<InputRun>, Vec<InputRun>)> {
     with_journal_mut(|j| j.take_last_programmatic_sequence_with_suffix())
+}
+
+#[must_use]
+pub fn take_last_sequence_with_suffix() -> Option<(Vec<InputRun>, Vec<InputRun>)> {
+    with_journal_mut(|j| j.take_last_sequence_with_suffix())
 }
 
 #[cfg(test)]

--- a/src/input_journal.rs
+++ b/src/input_journal.rs
@@ -1,5 +1,4 @@
 pub use crate::input::ring_buffer::{
     InputRun, LayoutTag, RunKind, RunOrigin, mark_last_token_autoconverted, push_run, push_runs,
-    take_last_layout_run_with_suffix, take_last_layout_sequence_with_suffix,
-    take_last_programmatic_sequence_with_suffix,
+    take_last_layout_run_with_suffix, take_last_sequence_with_suffix,
 };

--- a/src/tests/ring_buffer_tests.rs
+++ b/src/tests/ring_buffer_tests.rs
@@ -1,12 +1,9 @@
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::MutexGuard;
 
 use crate::input::ring_buffer::{self, InputRun, LayoutTag, RunKind, RunOrigin};
 
 fn test_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
+    ring_buffer::test_guard()
 }
 
 fn journal_text() -> String {
@@ -104,6 +101,98 @@ fn legacy_push_text_segments_internally() {
         suffix.iter().map(|r| r.text.as_str()).collect::<String>(),
         "   "
     );
+}
+
+#[test]
+fn take_last_layout_sequence_with_suffix_spans_same_origin_layout() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_runs([
+        InputRun {
+            text: "hello".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        },
+        InputRun {
+            text: " ".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Whitespace,
+        },
+        InputRun {
+            text: "world".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        },
+        InputRun {
+            text: "  ".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Whitespace,
+        },
+    ]);
+
+    let (runs, suffix) = ring_buffer::take_last_layout_sequence_with_suffix().expect("sequence");
+    assert_eq!(
+        runs.iter().map(|run| run.text.as_str()).collect::<String>(),
+        "hello world"
+    );
+    assert_eq!(
+        suffix
+            .iter()
+            .map(|run| run.text.as_str())
+            .collect::<String>(),
+        "  "
+    );
+}
+
+#[test]
+fn take_last_sequence_keeps_physical_prefix_before_programmatic_tail() {
+    let _guard = test_lock();
+    ring_buffer::invalidate();
+    ring_buffer::push_runs([
+        InputRun {
+            text: "hfp".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        },
+        InputRun {
+            text: " ".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Whitespace,
+        },
+        InputRun {
+            text: "ldf".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Text,
+        },
+        InputRun {
+            text: " ".to_string(),
+            layout: LayoutTag::En,
+            origin: RunOrigin::Physical,
+            kind: RunKind::Whitespace,
+        },
+        InputRun {
+            text: "три".to_string(),
+            layout: LayoutTag::Ru,
+            origin: RunOrigin::Programmatic,
+            kind: RunKind::Text,
+        },
+    ]);
+
+    let (runs, suffix) = ring_buffer::take_last_sequence_with_suffix().expect("sequence");
+    assert!(suffix.is_empty());
+    assert_eq!(
+        runs.iter().map(|run| run.text.as_str()).collect::<String>(),
+        "hfp ldf три"
+    );
+    assert_eq!(runs[0].origin, RunOrigin::Physical);
+    assert_eq!(runs[4].origin, RunOrigin::Programmatic);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Preserve the full last-phrase journal sequence after a last-word conversion, and add regression coverage for the double-Shift then double-Alt path.

## Problem
After converting only the last word, the journal ended with a programmatic run. Last-sequence extraction preferred that programmatic tail and therefore double-Alt could target only the last word instead of the whole phrase.

## Solution
Add a unified last-sequence extractor that keeps a contiguous physical phrase prefix when it is followed by a programmatic tail from word conversion. When converting such mixed-origin sequences, already-programmatic text is preserved so the fixed word is not toggled back while the physical prefix is converted.

## Scope
Includes input journal extraction, last-sequence conversion behavior, and regression tests for phrase buffer preservation. Does not change hotkey bindings or selection probing.

## Validation
- cargo +nightly fmt --check
- cargo +nightly clippy --all-targets --all-features -- -D warnings
- cargo +nightly build --features debug-tracing
- cargo +nightly test --locked
- actionlint -color
- zizmor --min-severity medium .

## Risks
Manual interactive verification in a live target app was not performed in this session; behavior is covered at journal/conversion level.