### PR TITLE
fix: propagate Dependabot discovery failures

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -160,7 +160,11 @@ jobs:
             echo "PR #$pr is not ready for auto-merge yet; leaving it open for the next trigger."
           }
 
-          mapfile -t prs < <(collect_prs)
+          prs_output="$(collect_prs)"
+          prs=()
+          if [ -n "$prs_output" ]; then
+            mapfile -t prs <<<"$prs_output"
+          fi
 
           if [ "${#prs[@]}" -eq 0 ]; then
             echo "No candidate Dependabot PRs found for event $GITHUB_EVENT_NAME."


### PR DESCRIPTION
Make the auto-merge workflow fail when `gh pr list` fails instead of treating an API error as an empty Dependabot queue.

This prevents transient GitHub API failures from being reported as successful no-op runs.

Validated with nightly fmt, Clippy, build, tests, actionlint, and zizmor.