### PR TITLE
fix: revoke stale unsafe auto-merge

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -97,6 +97,7 @@ jobs:
             local base_ref
             local head_ref
             local is_draft
+            local auto_merge_enabled
             local merge_state
             local title
             local merge_output
@@ -104,14 +105,15 @@ jobs:
             pr_json="$(
               gh pr view "$pr" \
                 --repo "$GH_REPO" \
-                --json number,title,author,baseRefName,headRefName,mergeStateStatus,isDraft \
-                --jq '{number: .number, title: .title, author: (.author.login // ""), baseRefName: .baseRefName, headRefName: .headRefName, mergeStateStatus: (.mergeStateStatus // ""), isDraft: .isDraft}'
+                --json number,title,author,baseRefName,headRefName,mergeStateStatus,isDraft,autoMergeRequest \
+                --jq '{number: .number, title: .title, author: (.author.login // ""), baseRefName: .baseRefName, headRefName: .headRefName, mergeStateStatus: (.mergeStateStatus // ""), isDraft: .isDraft, autoMergeEnabled: (.autoMergeRequest != null)}'
             )"
 
             author="$(jq -r '.author' <<<"$pr_json")"
             base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
             head_ref="$(jq -r '.headRefName' <<<"$pr_json")"
             is_draft="$(jq -r '.isDraft' <<<"$pr_json")"
+            auto_merge_enabled="$(jq -r '.autoMergeEnabled' <<<"$pr_json")"
             merge_state="$(jq -r '.mergeStateStatus' <<<"$pr_json")"
             title="$(jq -r '.title' <<<"$pr_json")"
 
@@ -136,6 +138,10 @@ jobs:
             fi
 
             if ! should_auto_merge "$head_ref" "$title"; then
+              if [ "$auto_merge_enabled" = "true" ]; then
+                echo "Disabling stale auto-merge for PR #$pr ($title)."
+                gh pr merge "$pr" --repo "$GH_REPO" --disable-auto
+              fi
               echo "Skipping PR #$pr ($title): auto-merge policy requires cargo updates or non-major GitHub Actions bumps."
               return 0
             fi


### PR DESCRIPTION
Disable an existing auto-merge request when a Dependabot PR no longer satisfies policy, such as a previously minor GitHub Action update being refreshed to a major version.

Validated with nightly fmt, Clippy, build, tests, actionlint, and zizmor.